### PR TITLE
Decouple Search from QTreeView (Phase 4)

### DIFF
--- a/docs/cleanup/findings.md
+++ b/docs/cleanup/findings.md
@@ -281,6 +281,29 @@ mod_data) shared by all filter types. `ModsFilter` additionally owns a
 dynamic grid of rows, a completer, and a debounce timer. Matching logic
 should be separable and testable without instantiating widgets.
 
+### F33. Filter activity flags are shared across searches — Likely
+
+Found during the Phase 4 spec verification pass (July 2026).
+`Filter::m_active` lives on the `Filter` object (`filters.h`), which is
+shared by every `Search`; per-search values live in `FilterData`.
+`m_active` is recomputed in `Filter::FromForm(FilterData *)` — i.e.
+whenever a search reads the form, normally the *current* one.
+`Search::FilterItems()` builds its active-filter list via
+`filter->filter()->IsActive()`, so it filters with the current search's
+activity flags against its own search's values. Exposed path:
+`MainWindow::OnItemsRefreshed()` calls `FilterItems()` on every
+*background* search — a background search with a saved name query will skip
+that filter entirely if the current search's name box is empty, producing
+wrong buckets and caption counts until that search is next activated.
+"Likely" because traced end-to-end but not runtime-verified. Fix belongs to
+Phase 5, whose per-search typed state absorbs activity — this upgrades its
+"activity must move into the state structs" hazard from refactoring note to
+correctness fix; pin the current wrong behavior with a characterization
+test at the start of Phase 5. Note the phase-5 doc's hazard wording
+("`FilterData::FromForm()` is also where `m_active` gets computed")
+misplaces it: `m_active` is on `Filter`, not `FilterData` — the
+misattribution is the bug.
+
 ### F20. `MainWindow` owns workflow state — Confirmed
 
 Raw-pointer ownership of `Search*` objects with manual `delete`, current
@@ -434,3 +457,14 @@ through a tab that filters the item out clears the global pointer (and now
 also clears the item detail panel, which previously went stale), so the
 selection is lost in that case. The expansion-state symptom and the
 underlying ownership problem are unchanged and remain deferred.
+
+Decision (July 2026, Phase 4 spec upgrade): F32 is deferred to Phase 6, not
+absorbed into Phase 4. Phase 4's verification gate is behavior-identical
+relocation; fixing F32 changes user-visible behavior and would invalidate
+that gate (the F31 lesson applied in advance). Phase 4 does make the fix
+cheap: `MainWindow` owns the expansion save/restore adapters after it, so
+the expansion half becomes a single `SaveViewExpansion()` call in
+`OnTabChange()` before switching `m_current_search`; the selection half
+requires per-search current-item state, which belongs with Phase 6's
+`MainWindow` slimming (item 6.6, alongside 6.5's `OnLayoutChanged` work —
+do the two together).

--- a/docs/cleanup/findings.md
+++ b/docs/cleanup/findings.md
@@ -316,6 +316,23 @@ UI consumer.
 
 ## Recorded but out of scope
 
+### F34. `Bucket::Sort` inverts the Qt sort-order semantics — Confirmed
+
+Found during the Phase 4 review while hardening
+`tst_itemsmodel::selectionSurvivesSort`. `Bucket::Sort()` (`bucket.cpp`)
+maps `Qt::AscendingOrder` to `column.lt(rhs, lhs)` — a *descending*
+arrangement — and `Qt::DescendingOrder` to ascending; `Column::lt` is a
+plain less-than, so nothing cancels the inversion. User-visible symptom:
+the header sort-indicator arrow points opposite to the actual row order
+(e.g. an "ascending" indicator shows Z→A). Pre-existing and long-shipped;
+Phase 4 did not touch sorting. Fixing it flips behavior users may have
+acclimated to, so it needs its own deliberate change (swap the two lambda
+branches, re-check the persistent-index remap test, release-note it) —
+out of scope for the cleanup phases unless Phase 6 wants it as an
+opportunistic item. `tst_itemsmodel` deliberately asserts only that a
+re-sort *changes* the arrangement, not which direction each enum produces,
+so it will survive the fix.
+
 ### F21. Every `Item` stores its raw JSON — Confirmed (impact unmeasured)
 
 `Item::m_json` keeps the full JSON text of each item. With the large stash

--- a/docs/cleanup/phase-4-search-decoupling.md
+++ b/docs/cleanup/phase-4-search-decoupling.md
@@ -1,81 +1,301 @@
 # Phase 4: Decouple `Search` from `QTreeView`
 
-> **Staleness warning.** This spec is design intent, written July 2026 before
-> Phases 0–3 were implemented. It assumes their landed state — in particular
-> Phase 3's reset discipline, without which this phase is not safe. Re-derive
-> the step details from the code at implementation time; trust the intent,
-> not the line-level claims.
+> **Spec upgrade (July 2026).** Rewritten from design intent to an
+> implementation-grade spec after Phases 0–3 merged; every code fact below
+> was re-verified against `design-cleanup` @ 5d665da. The original
+> staleness warning no longer applies.
 
 ## Assumptions
 
-- Phase 3 landed: `ItemsModel` brackets rebuilds with resets; `Search` no
-  longer calls `m_view.reset()`/`blockSignals`; `MainWindow` owns the two
-  view connections.
-- `Search` still takes `QTreeView *` in its constructor, stores `m_view`, and
-  uses it in `Activate` (setModel + sort indicator) and
-  `SaveViewProperties`/`RestoreViewProperties` (expansion read/write).
+Code facts this spec was verified against — spot-check before implementing:
+
+- Phase 3 landed as amended: `ItemsModel` brackets rebuilds with
+  `beginUpdate()`/`endUpdate()`; `sort()` emits a proper
+  `layoutAboutToBeChanged`/`layoutChanged` pair with persistent-index
+  remapping; `MainWindow` stores the two view connections as
+  `QMetaObject::Connection` handles and calls `OnLayoutChanged()` explicitly
+  at the end of `ModelViewRefresh()`.
+- `Search` takes `QTreeView *` in its constructor and stores
+  `QTreeView &m_view`. The complete list of `m_view` uses (grep-verified):
+  - `Activate()`: `setSortingEnabled(false)` → conditional `setModel` →
+    `header()->setSortIndicator(...)` → `setSortingEnabled(true)` →
+    `RestoreViewProperties()`.
+  - `SaveViewProperties()`: `isExpanded()` per top-level row.
+  - `RestoreViewProperties()`: `expandToDepth(0)` / per-row
+    `expand()`/`collapse()`.
+- **The rebuild's re-sort is view-triggered.** `FilterItems()` ends with
+  `SetSorted(false)`; `Activate()`'s `setSortingEnabled(true)` makes
+  `QTreeView` re-apply the header sort, calling `ItemsModel::sort()`, which
+  actually sorts because the sorted flag is down. That sort is the only
+  `layoutChanged` of a rebuild and fires while `ModelViewRefresh()` has the
+  connections down — hence the explicit `OnLayoutChanged()` at its end
+  (Phase 3 pre-merge amendment). On the `TabChanged` path `FilterItems()`
+  early-returns (flag stays up) and the triggered sort no-ops via the
+  `m_sorted` guard.
+- `SetViewMode()` no longer touches the view directly, but calls
+  `SaveViewProperties()`/`RestoreViewProperties()` internally around its
+  reset bracket.
+- `ItemsModel` is a private member of `Search` with **no public accessor**;
+  `MainWindow` and the tests reach it only via `ui->treeView->model()` /
+  `view.model()`.
+- Call-site inventory (complete, grep-verified):
+  - `Activate`: `MainWindow::ModelViewRefresh()` (only app caller);
+    `tst_itemsmodel.cpp` ×2 (used there to attach the model to a view).
+  - `SaveViewProperties`: `MainWindow::OnSearchFormChange()` (before
+    `ModelViewRefresh()`); internally from `SetViewMode()`.
+  - `RestoreViewProperties`: internally from `Activate()` and
+    `SetViewMode()` only.
+  - `SetViewMode`: the `viewComboBox` lambda in the `MainWindow`
+    constructor; `tst_search.cpp` ×2; `tst_itemsmodel.cpp` ×1.
+  - `ModelViewRefresh()` callers: `OnSearchFormChange()` (save-before),
+    `OnTabChange()` (no save — F32), `NewSearch()`, `OnItemsRefreshed()`
+    (no save).
+  - `Search` construction: `MainWindow::NewSearch()`; `tst_search.cpp` ×2;
+    `tst_itemsmodel.cpp` ×2.
+- F31 aftermath: `QTreeView::expanded`/`collapsed` are connected to
+  `ScheduleResizeTreeColumns()` (0 ms coalescing timer). Two `MainWindow`
+  comments name code this phase moves: the connection comment (names
+  `Search::RestoreViewProperties`) and the `viewComboBox` lambda comment
+  (says `SetViewMode()` restores expansion).
+
+## Current expansion semantics (behavior gate — preserve exactly)
+
+`SaveViewProperties()` unconditionally clears the saved header set, then
+repopulates it only when `!m_filtered && mode == ByTab`.
+`RestoreViewProperties()` expands everything when `m_filtered || ByItem`;
+otherwise it applies the saved set per row, with an empty set collapsing
+every row. Consequences — all current behavior, none changed by this phase:
+
+| Action | Behavior today |
+|---|---|
+| Form change, unfiltered ByTab → unfiltered ByTab | expansion preserved |
+| Applying a filter | everything expanded |
+| Form change while filtered | everything stays expanded |
+| Clearing a filter (filtered → unfiltered) | **all tabs collapse** (save ran while still filtered → set wiped → empty set collapses all) |
+| ByTab → ByItem | everything expanded |
+| ByItem → ByTab | **all tabs collapse** (save ran in ByItem → set wiped) |
+| Switching search tabs | incoming search restores its last-*saved* set; outgoing search saves nothing (F32 — unchanged, see Non-Goals) |
+| Items refreshed | no save; restore from last-saved set |
+
+The original draft's acceptance criterion "expansion preserved across filter
+changes, tab switches, and view-mode switches" contradicted both this table
+and the phase's own non-goal — the F31 shape. The criteria below are written
+against the table.
 
 ## Goal
 
 `Search` becomes pure state — items, buckets, filter data, columns, view
-mode, sort state, and *expansion state as data* — with no widget references.
-`MainWindow` adapts that state to the `QTreeView`. Finding addressed: F18.
+mode, sort state, and expansion state as data — with no `QTreeView`
+references. `MainWindow` adapts that state to the view. Finding addressed:
+F18.
 
 ## Non-Goals
 
-- No filter rework (Phase 5).
-- No change to expansion/selection behavior; this is a relocation of
-  responsibilities, verified by identical smoke behavior.
+- No filter rework (Phase 5). `Search` remains *transitively*
+  widget-dependent through `filters.h` (`FromForm()` reads widgets) until
+  Phase 5; this phase removes only the direct `QTreeView` coupling.
+- No change to expansion/selection behavior: this is a relocation of
+  responsibilities, verified by the behavior table staying identical —
+  including its two "all tabs collapse" quirks, which are easy to
+  accidentally "fix".
+- **F32 is deferred to Phase 6** (decision, July 2026): fixing it changes
+  user-visible behavior, which would destroy this phase's
+  identical-behavior gate. This phase makes the fix cheap: once
+  `MainWindow` owns the save adapter, the expansion half of F32 is one
+  `SaveViewExpansion()` call in `OnTabChange()`; the selection half needs
+  per-search current-item state (Phase 6, alongside item 6.5). See F32 in
+  `findings.md` and item 6.6 in `phase-6-mainwindow-slimming.md`.
+- The F31 resize coalescing (`ScheduleResizeTreeColumns`) is not touched.
+- No renames beyond what the relocation forces; `Search::Activate` keeps
+  its name (now data-only).
 
 ## Design
 
-- **Constructor:** drop the `QTreeView *` parameter. `Search` keeps owning
-  `ItemsModel` (it already constructs it with `*this`).
-- **Activation:** `Search::Activate(items)` reduces to data work (`FromForm`,
-  `FilterItems`, restore sort). The view work moves to a `MainWindow` helper
-  (natural home: `ModelViewRefresh`):
-  - `setModel` when the view's model differs,
-  - header sort indicator from `model.GetSortColumn()/GetSortOrder()`,
-  - expansion restore (below).
-- **Expansion state:** `Search` keeps the *data* (`std::set<QString>` of
-  expanded location headers — same keying as today) with accessors roughly:
+### New `Search` API
 
-  ```cpp
-  const std::set<QString> &expandedHeaders() const;
-  void setExpandedHeaders(std::set<QString> headers);
-  bool defaultExpanded() const;   // filtered || ByItem mode → expand all
-  ```
+```cpp
+// Search (public)
+ItemsModel &model() { return m_model; }
+const std::set<QString> &expandedHeaders() const { return m_expanded_property; }
+void setExpandedHeaders(std::set<QString> headers);   // moves into m_expanded_property
+bool defaultExpanded() const { return m_filtered || (m_current_mode == ViewMode::ByItem); }
+```
 
-  `MainWindow` implements the two adapters: *save* (walk top-level rows, ask
-  the view `isExpanded`, map row → header via `Search::bucket()`) and
-  *restore* (apply header set / defaultExpanded to the view). These are the
-  bodies of today's `SaveViewProperties`/`RestoreViewProperties` with the
-  view passed in from outside; preserve their exact semantics, including the
-  "empty set means collapse everything" branch.
-- **`SetViewMode`:** stays in `Search` (it is data + model reset after Phase
-  3); the expansion save/restore around it moves to the caller.
-- **Call-path inventory before editing:** every `SaveViewProperties`/
-  `RestoreViewProperties`/`Activate` call site in `mainwindow.cpp` must be
-  re-anchored; list them with grep first and keep the save-before-rebuild /
-  restore-after-rebuild ordering established in Phase 3.
+`model()` is required because `MainWindow` takes over `setModel` and the
+tests currently reach the model only through the view. `defaultExpanded()`
+encodes both branches of today's logic: restore expands-all exactly when it
+is true, and save records headers exactly when it is false (with two view
+modes, `!defaultExpanded()` ≡ `!m_filtered && ByTab`).
+
+### MainWindow adapters
+
+Two private `MainWindow` methods, bodies lifted from today's `Search`
+methods with `ui->treeView` in place of `m_view`:
+
+```cpp
+void MainWindow::SaveViewExpansion(Search &search)
+{
+    std::set<QString> expanded;
+    if (!search.defaultExpanded()) {
+        const int rows = search.model().rowCount();
+        for (int row = 0; row < rows; ++row) {
+            const QModelIndex index = search.model().index(row, 0);
+            if (index.isValid() && ui->treeView->isExpanded(index) && search.has_bucket(row)) {
+                expanded.emplace(search.bucket(row).location().GetHeader());
+            }
+        }
+    }
+    search.setExpandedHeaders(std::move(expanded));
+}
+
+void MainWindow::RestoreViewExpansion(Search &search)
+{
+    if (search.defaultExpanded()) {
+        ui->treeView->expandToDepth(0);
+        return;
+    }
+    const auto &headers = search.expandedHeaders();
+    const int rows = search.model().rowCount();
+    for (int row = 0; row < rows; ++row) {
+        const QModelIndex index = search.model().index(row, 0);
+        if (headers.empty()) {
+            ui->treeView->collapse(index);
+        } else if (headers.count(search.bucket(row).location().GetHeader()) > 0) {
+            ui->treeView->expand(index);
+        } else {
+            ui->treeView->collapse(index);
+        }
+    }
+}
+```
+
+The **unconditional** `setExpandedHeaders` in the save adapter is
+load-bearing: it reproduces today's `m_expanded_property.clear()` at the top
+of `SaveViewProperties()`, which produces the two "all tabs collapse" rows
+of the behavior table. The empty-set-collapses-everything branch in restore
+is likewise deliberate. Do not "fix" either here.
+
+### Activation
+
+`Search::Activate(items)` reduces to data work: `FromForm();
+FilterItems(items);`. The view work moves into `ModelViewRefresh()`, in
+exactly today's order, in the slot where `Activate()` is called today —
+i.e. while the two connections are down:
+
+```cpp
+disconnect(m_current_item_conn);
+disconnect(m_layout_changed_conn);
+m_buyout_manager.Save();
+m_current_search->Activate(m_items_manager.items());   // data only now
+ItemsModel &model = m_current_search->model();
+ui->treeView->setSortingEnabled(false);
+if (ui->treeView->model() != &model) {
+    ui->treeView->setModel(&model);                     // tab switch only
+}
+ui->treeView->header()->setSortIndicator(model.GetSortColumn(), model.GetSortOrder());
+ui->treeView->setSortingEnabled(true);  // triggers the re-sort; the rebuild's only
+                                        // layoutChanged fires here, unseen
+RestoreViewExpansion(*m_current_search);
+ScheduleResizeTreeColumns();
+// reconnect both connections, viewComboBox index, tab text — unchanged
+OnLayoutChanged();   // unchanged (Phase 3 amendment); reword its comment, which names Activate()
+```
+
+**Decision — the re-sort stays view-triggered.** The alternative (having
+`Activate()` sort its own data) was considered and rejected: it would emit
+the sort's layout signals before the view is attached on tab switches and
+reorder today's signal sequence for no benefit. `setSortingEnabled(true)`
+plus the model's `m_sorted` guard already behaves correctly on every path,
+including the `TabChanged` no-op.
+
+### SetViewMode
+
+The internal save/restore calls move to the only app caller, the
+`viewComboBox` lambda:
+
+```cpp
+SaveViewExpansion(*m_current_search);
+m_current_search->SetViewMode(static_cast<Search::ViewMode>(n));
+RestoreViewExpansion(*m_current_search);
+ScheduleResizeTreeColumns();
+```
+
+`SetViewMode()` keeps its reset bracket + re-sort (data + model work). The
+save must run *before* `SetViewMode()` (it reads expansion under the
+*outgoing* mode's `defaultExpanded()`), the restore *after* (the reset
+collapsed everything) — the same ordering as today's internal calls. Update
+the lambda's comment, which currently says `SetViewMode()` restores
+expansion.
+
+### Comment fixes
+
+Reword the comments that name moved code: the `expanded`/`collapsed`
+connection comment in the `MainWindow` constructor
+("e.g. Search::RestoreViewProperties after a model reset"), the
+`OnLayoutChanged()` comment at the end of `ModelViewRefresh()` ("Activate()
+rebuilds and re-sorts…"), the `viewComboBox` lambda comment, and
+`search.h`'s comment on `Activate` ("will display items in passed
+QTreeView").
 
 ## Steps
 
-1. Add the expansion-state accessors to `Search`; reimplement
-   `Save/RestoreViewProperties` as `MainWindow` helpers using them; delete
-   the `Search` methods.
-2. Move `Activate`'s view work into `ModelViewRefresh`; shrink `Activate` to
-   data work.
-3. Remove `QTreeView *` from the constructor and the `m_view` member; update
-   `NewSearch()`.
-4. Update tests: `tst_search` no longer needs a `QTreeView`; switch it to
-   `QTEST_GUILESS_MAIN` if nothing else in it requires widgets (filters still
-   do until Phase 5 — if the fixture builds filters, it stays `QTEST_MAIN`).
+Each step compiles and passes `ctest` on its own.
+
+1. **Add the `Search` accessors**: `model()`, `expandedHeaders()`,
+   `setExpandedHeaders()`, `defaultExpanded()`. Pure addition.
+2. **Relocate expansion save/restore.** Add `SaveViewExpansion`/
+   `RestoreViewExpansion` to `MainWindow`. Re-anchor:
+   `OnSearchFormChange()` calls `SaveViewExpansion` instead of
+   `search->SaveViewProperties()`; the `viewComboBox` lambda wraps
+   `SetViewMode()` with save/restore; `ModelViewRefresh()` calls
+   `RestoreViewExpansion` right after `Activate()` (replacing the restore
+   `Activate()` did internally). Delete `Search::SaveViewProperties`/
+   `RestoreViewProperties` and their internal calls in
+   `Activate()`/`SetViewMode()`. Fix the affected comments.
+3. **Move `Activate()`'s remaining view work into `ModelViewRefresh()`**
+   per the Design listing; `Activate()` becomes `FromForm();
+   FilterItems(items);`.
+4. **Drop the view from `Search`**: remove the `QTreeView *` constructor
+   parameter and `m_view`; update `NewSearch()`; remove the `<QTreeView>`/
+   `<QHeaderView>` includes from `search.cpp` and the `QTreeView` forward
+   declaration from `search.h`. (After step 3 nothing uses `m_view`, so
+   steps 3 and 4 can be separate commits.)
+5. **Update tests.**
+   - `tst_itemsmodel.cpp`: construct `Search` without a view; attach with
+     `view.setModel(&search.model())` after `search.Activate(items)`; the
+     `qobject_cast<ItemsModel *>(view.model())` indirection can become
+     `&search.model()`. Note the initial sort state changes: today the
+     view-attach inside `Activate()` leaves the model sorted (column 0
+     descending); after this phase the model starts unsorted, and the
+     explicit `model->sort(...)` calls still proceed (the `m_sorted` guard
+     is down). Both tests' assertions hold as written — re-verify
+     `selectionSurvivesSort`'s pre-sort row expectations when touching it.
+     Keeps `QTEST_MAIN` (it constructs a `QTreeView` for the selection
+     model).
+   - `tst_search.cpp`: drop the `QTreeView` member from `SearchHarness` and
+     the `&harness.view` arguments. Stays `QTEST_MAIN`: the fixture builds
+     filter widgets (`QLineEdit` etc.), which need a `QApplication` until
+     Phase 5.
 
 ## Acceptance criteria
 
+Checked against the Non-Goals: the grep below is satisfiable because every
+view manipulation moves to `mainwindow.cpp`, where view code belongs; no
+non-goal protects anything the grep would flag (contrast F31, where the
+grep demanded removing something a non-goal protected).
+
 - `grep -n 'QTreeView' src/search.h src/search.cpp` → empty.
-- Build + `ctest` green; `QAbstractItemModelTester` test still passes.
-- Manual smoke focus: expansion preserved across filter changes, tab
-  switches, and view-mode switches; sort indicator correct after switching
-  tabs; current-item reselection after filtering unchanged.
+- Build + full `ctest` green; the `QAbstractItemModelTester` test still
+  passes.
+- Manual smoke, gated on the behavior table staying identical, with
+  specific attention to:
+  - the two "all tabs collapse" quirks (filter-clear, ByItem→ByTab round
+    trip) still behaving exactly as before;
+  - sort indicator correct per-search after switching tabs; filter changes
+    still re-sort (view-triggered path intact);
+  - current-item reselection / item-panel clearing after filter changes
+    unchanged (the explicit `OnLayoutChanged()` still runs);
+  - view-mode switches stay responsive (F31 coalescing: one deferred
+    column resize per switch);
+  - tab switches: expansion still reverts to last-saved state (F32
+    unchanged — do not accidentally fix it here either).

--- a/docs/cleanup/phase-6-mainwindow-slimming.md
+++ b/docs/cleanup/phase-6-mainwindow-slimming.md
@@ -10,7 +10,7 @@
 
 Clean up what the earlier phases deliberately deferred, without introducing
 a controller architecture. Findings addressed: F20 (scoped down), F9
-remainder, F14. Optionally F22.
+remainder, F14, F32. Optionally F22.
 
 ## Explicit non-goal, restated
 
@@ -66,7 +66,19 @@ storage, or document the split clearly in the code. Skip freely.
 Deferred from Phase 3: if the selection-model exceptions its comments
 describe are confirmed gone (post Phase 3 resets + persistent-index sorts),
 the manual reset/reselect can likely shrink. Verify with the Phase 3 smoke
-list before and after.
+list before and after. Coordinate with 6.6 — both touch the current-item
+handling.
+
+### 6.6 Fix F32 (per-search view state on tab switch)
+
+Deferred from Phase 4 (see the decision recorded in F32). Expansion half:
+call the Phase 4 `SaveViewExpansion()` adapter on the outgoing search in
+`OnTabChange()` before switching `m_current_search`. Selection half: the
+current item is global (`m_current_item`); making it per-search interacts
+with 6.5's `OnLayoutChanged` simplification — do the two together.
+Deliberate behavior change: switching search tabs and back preserves
+expansion and selection where it previously reverted to last-saved
+expansion and (sometimes) lost the selection; note it in the release notes.
 
 ## Acceptance criteria
 

--- a/docs/cleanup/plan.md
+++ b/docs/cleanup/plan.md
@@ -51,12 +51,12 @@ codebase strictly better off.
 | 1. Layering fixes | `phase-1-layering.md` | F3, F6–F8, F13, F15, F16, F17, F26 | Done |
 | 2. Worker threading + update state machine | `phase-2-worker-threading.md` | F1, F2, F4, F5, F24, F27, F29, F30 | Done |
 | 3. Model/view signal hygiene | `phase-3-model-signals.md` | F10–F12, F23, F25 | Done |
-| 4. Decouple `Search` from `QTreeView` | `phase-4-search-decoupling.md` | F18 | Spec ready |
+| 4. Decouple `Search` from `QTreeView` | `phase-4-search-decoupling.md` | F18 | Done |
 | 5. Filters as data + matching | `phase-5-filters-as-data.md` | F19, F33 | Design intent |
 | 6. Opportunistic `MainWindow` slimming | `phase-6-mainwindow-slimming.md` | F20, F9 remainder, F14, F32 | Design intent |
 
-Phases 0–3 are the committed core. Phase 4's spec was upgraded to
-implementation grade in July 2026 (verified against the post-Phase-3 code).
+Phases 0–4 are the committed core. Phase 4's spec was upgraded to
+implementation grade in July 2026 and implemented against the post-Phase-3 code.
 Phases 5–6 are worthwhile continuations with full design intent documented,
 but their step-by-step details must be re-verified against the codebase
 state at implementation time.

--- a/docs/cleanup/plan.md
+++ b/docs/cleanup/plan.md
@@ -51,13 +51,15 @@ codebase strictly better off.
 | 1. Layering fixes | `phase-1-layering.md` | F3, F6–F8, F13, F15, F16, F17, F26 | Done |
 | 2. Worker threading + update state machine | `phase-2-worker-threading.md` | F1, F2, F4, F5, F24, F27, F29, F30 | Done |
 | 3. Model/view signal hygiene | `phase-3-model-signals.md` | F10–F12, F23, F25 | Done |
-| 4. Decouple `Search` from `QTreeView` | `phase-4-search-decoupling.md` | F18 | Design intent |
-| 5. Filters as data + matching | `phase-5-filters-as-data.md` | F19 | Design intent |
-| 6. Opportunistic `MainWindow` slimming | `phase-6-mainwindow-slimming.md` | F20, F9 remainder, F14 | Design intent |
+| 4. Decouple `Search` from `QTreeView` | `phase-4-search-decoupling.md` | F18 | Spec ready |
+| 5. Filters as data + matching | `phase-5-filters-as-data.md` | F19, F33 | Design intent |
+| 6. Opportunistic `MainWindow` slimming | `phase-6-mainwindow-slimming.md` | F20, F9 remainder, F14, F32 | Design intent |
 
-Phases 0–3 are the committed core. Phases 4–6 are worthwhile continuations
-with full design intent documented, but their step-by-step details must be
-re-verified against the codebase state at implementation time.
+Phases 0–3 are the committed core. Phase 4's spec was upgraded to
+implementation grade in July 2026 (verified against the post-Phase-3 code).
+Phases 5–6 are worthwhile continuations with full design intent documented,
+but their step-by-step details must be re-verified against the codebase
+state at implementation time.
 
 ### Phase summaries
 
@@ -135,7 +137,10 @@ state); `MainWindow` owns the adaptation to `QTreeView`. After Phases 3 and
 **Phase 5 — Filters as data.** Separate filter definition + matching (core,
 testable) from widget construction (UI). Replace the `FilterData` grab-bag
 with per-filter typed state. `ModsFilter` migrates last — it is the most
-complex (dynamic rows, completer, debounce).
+complex (dynamic rows, completer, debounce). Also fixes F33 (filter
+activity flags are shared across searches, so background searches can be
+mis-filtered after an items refresh) — per-search state absorbs the
+activity flag.
 
 **Phase 6 — MainWindow slimming.** Opportunistic only: extract the dialog
 classes out of `currencymanager.h`, move `Search*` ownership to

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,6 +85,11 @@ void Search::ResetForm()
     }
 }
 
+void Search::setExpandedHeaders(std::set<QString> headers)
+{
+    m_expanded_property = std::move(headers);
+}
+
 const std::vector<Bucket> &Search::buckets() const
 {
     switch (m_current_mode) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -324,15 +324,11 @@ ItemLocation Search::GetTabLocation(const QModelIndex &index) const
 void Search::SetViewMode(ViewMode mode)
 {
     if (mode != m_current_mode) {
-        SaveViewProperties();
-
         m_model.beginUpdate();
         m_current_mode = mode;
         Sort(m_model.GetSortColumn(), m_model.GetSortOrder());
         m_model.SetSorted(true);
         m_model.endUpdate();
-
-        RestoreViewProperties();
     }
 }
 
@@ -346,43 +342,4 @@ void Search::Activate(const Items &items)
     }
     m_view.header()->setSortIndicator(m_model.GetSortColumn(), m_model.GetSortOrder());
     m_view.setSortingEnabled(true);
-    RestoreViewProperties();
-}
-
-void Search::SaveViewProperties()
-{
-    m_expanded_property.clear();
-    if (!m_filtered && (m_current_mode == Search::ViewMode::ByTab)) {
-        const int rowCount = m_model.rowCount();
-        for (int row = 0; row < rowCount; ++row) {
-            QModelIndex index = m_model.index(row, 0, QModelIndex());
-            if (index.isValid() && m_view.isExpanded(index)) {
-                if (has_bucket(row)) {
-                    m_expanded_property.emplace(bucket(row).location().GetHeader());
-                }
-            }
-        }
-    }
-}
-
-void Search::RestoreViewProperties()
-{
-    if (m_filtered || (m_current_mode == Search::ViewMode::ByItem)) {
-        m_view.expandToDepth(0);
-    } else {
-        const int row_count = m_model.rowCount();
-        for (int row = 0; row < row_count; ++row) {
-            QModelIndex index = m_model.index(row, 0, QModelIndex());
-            if (m_expanded_property.empty()) {
-                m_view.collapse(index);
-            } else {
-                const auto key = bucket(row).location().GetHeader();
-                if (m_expanded_property.count(key) > 0) {
-                    m_view.expand(index);
-                } else {
-                    m_view.collapse(index);
-                }
-            }
-        }
-    }
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -336,10 +336,4 @@ void Search::Activate(const Items &items)
 {
     FromForm();
     FilterItems(items);
-    m_view.setSortingEnabled(false);
-    if (m_view.model() != &m_model) {
-        m_view.setModel(&m_model);
-    }
-    m_view.header()->setSortIndicator(m_model.GetSortColumn(), m_model.GetSortOrder());
-    m_view.setSortingEnabled(true);
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -3,9 +3,6 @@
 
 #include "search.h"
 
-#include <QHeaderView>
-#include <QTreeView>
-
 #include <memory>
 
 #include "bucket.h"
@@ -18,10 +15,8 @@
 
 Search::Search(BuyoutManager &bo_manager,
                const QString &caption,
-               const std::vector<std::unique_ptr<Filter>> &filters,
-               QTreeView *view)
+               const std::vector<std::unique_ptr<Filter>> &filters)
     : m_bo_manager(bo_manager)
-    , m_view(*view)
     , m_model(bo_manager, *this)
     , m_caption(caption)
     , m_filtered(false)

--- a/src/search.h
+++ b/src/search.h
@@ -44,17 +44,12 @@ public:
     ItemsModel &model() { return m_model; }
     const std::set<QString> &expandedHeaders() const { return m_expanded_property; }
     void setExpandedHeaders(std::set<QString> headers);
-    bool defaultExpanded() const
-    {
-        return m_filtered || (m_current_mode == ViewMode::ByItem);
-    }
+    bool defaultExpanded() const { return m_filtered || (m_current_mode == ViewMode::ByItem); }
     const std::vector<Bucket> &buckets() const;
     void RenameCaption(const QString &newName);
     QString GetCaption() const;
     // Sets this search as current, will display items in passed QTreeView.
     void Activate(const Items &items);
-    void RestoreViewProperties();
-    void SaveViewProperties();
     ItemLocation GetTabLocation(const QModelIndex &index) const;
     void SetViewMode(ViewMode mode);
     ViewMode GetViewMode() const { return m_current_mode; }

--- a/src/search.h
+++ b/src/search.h
@@ -48,7 +48,7 @@ public:
     const std::vector<Bucket> &buckets() const;
     void RenameCaption(const QString &newName);
     QString GetCaption() const;
-    // Sets this search as current, will display items in passed QTreeView.
+    // Updates this search from the current form and item data.
     void Activate(const Items &items);
     ItemLocation GetTabLocation(const QModelIndex &index) const;
     void SetViewMode(ViewMode mode);

--- a/src/search.h
+++ b/src/search.h
@@ -20,7 +20,6 @@ class BuyoutManager;
 class Filter;
 class FilterData;
 class ItemsModel;
-class QTreeView;
 class QModelIndex;
 
 class Search
@@ -32,8 +31,7 @@ public:
 
     Search(BuyoutManager &bo,
            const QString &caption,
-           const std::vector<std::unique_ptr<Filter>> &filters,
-           QTreeView *view);
+           const std::vector<std::unique_ptr<Filter>> &filters);
     void FilterItems(const Items &items);
     void FromForm();
     void ToForm();
@@ -63,7 +61,6 @@ private:
     std::vector<Bucket> &active_buckets();
 
     BuyoutManager &m_bo_manager;
-    QTreeView &m_view;
 
     std::vector<std::unique_ptr<FilterData>> m_filters;
     std::vector<std::unique_ptr<Column>> m_columns;

--- a/src/search.h
+++ b/src/search.h
@@ -41,6 +41,13 @@ public:
     const QString &caption() const { return m_caption; }
     const Items &items() const { return m_items; }
     const std::vector<std::unique_ptr<Column>> &columns() const { return m_columns; }
+    ItemsModel &model() { return m_model; }
+    const std::set<QString> &expandedHeaders() const { return m_expanded_property; }
+    void setExpandedHeaders(std::set<QString> headers);
+    bool defaultExpanded() const
+    {
+        return m_filtered || (m_current_mode == ViewMode::ByItem);
+    }
     const std::vector<Bucket> &buckets() const;
     void RenameCaption(const QString &newName);
     QString GetCaption() const;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -27,6 +27,7 @@
 #include <QTabBar>
 #include <QVersionNumber>
 
+#include <set>
 #include <vector>
 
 #include "buyoutmanager.h"
@@ -215,11 +216,12 @@ void MainWindow::InitializeUi()
 
     ui->viewComboBox->addItems({"By Tab", "By Item"});
     connect(ui->viewComboBox, &QComboBox::activated, this, [&](int n) {
-        // SetViewMode() restores the expansion state for the new mode, which
-        // schedules a column resize via the expanded/collapsed signals. Also
-        // schedule one here because column contents change between modes even
-        // when the expansion state does not.
+        SaveViewExpansion(*m_current_search);
         m_current_search->SetViewMode(static_cast<Search::ViewMode>(n));
+        RestoreViewExpansion(*m_current_search);
+        // Restoring expansion schedules a resize via the expanded/collapsed
+        // signals. Also schedule one here because column contents change
+        // between modes even when the expansion state does not.
         ScheduleResizeTreeColumns();
     });
 
@@ -285,8 +287,8 @@ void MainWindow::InitializeUi()
     });
 
     // Resize columns when a tab is expanded/collapsed. Programmatic expansion
-    // (e.g. Search::RestoreViewProperties after a model reset) emits these
-    // signals once per index, so coalesce them into a single deferred resize.
+    // (e.g. RestoreViewExpansion after a model reset) emits these signals once
+    // per index, so coalesce them into a single deferred resize.
     connect(ui->treeView, &QTreeView::collapsed, this, &MainWindow::ScheduleResizeTreeColumns);
     connect(ui->treeView, &QTreeView::expanded, this, &MainWindow::ScheduleResizeTreeColumns);
 
@@ -665,9 +667,44 @@ void MainWindow::OnDeleteTabClicked(int index)
 void MainWindow::OnSearchFormChange()
 {
     spdlog::trace("MainWindow::OnSearchFormChange() entered");
-    m_current_search->SaveViewProperties();
+    SaveViewExpansion(*m_current_search);
     m_current_search->SetRefreshReason(RefreshReason::SearchFormChanged);
     ModelViewRefresh();
+}
+
+void MainWindow::SaveViewExpansion(Search &search)
+{
+    std::set<QString> expanded;
+    if (!search.defaultExpanded()) {
+        const int rows = search.model().rowCount();
+        for (int row = 0; row < rows; ++row) {
+            const QModelIndex index = search.model().index(row, 0);
+            if (index.isValid() && ui->treeView->isExpanded(index) && search.has_bucket(row)) {
+                expanded.emplace(search.bucket(row).location().GetHeader());
+            }
+        }
+    }
+    search.setExpandedHeaders(std::move(expanded));
+}
+
+void MainWindow::RestoreViewExpansion(Search &search)
+{
+    if (search.defaultExpanded()) {
+        ui->treeView->expandToDepth(0);
+        return;
+    }
+    const auto &headers = search.expandedHeaders();
+    const int rows = search.model().rowCount();
+    for (int row = 0; row < rows; ++row) {
+        const QModelIndex index = search.model().index(row, 0);
+        if (headers.empty()) {
+            ui->treeView->collapse(index);
+        } else if (headers.count(search.bucket(row).location().GetHeader()) > 0) {
+            ui->treeView->expand(index);
+        } else {
+            ui->treeView->collapse(index);
+        }
+    }
 }
 
 void MainWindow::ModelViewRefresh()
@@ -680,6 +717,7 @@ void MainWindow::ModelViewRefresh()
 
     spdlog::trace("MainWindow::ModelViewRefresh() activing current search");
     m_current_search->Activate(m_items_manager.items());
+    RestoreViewExpansion(*m_current_search);
     ScheduleResizeTreeColumns();
 
     // This updates the item information when current item changes.

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -216,9 +216,15 @@ void MainWindow::InitializeUi()
 
     ui->viewComboBox->addItems({"By Tab", "By Item"});
     connect(ui->viewComboBox, &QComboBox::activated, this, [&](int n) {
-        SaveViewExpansion(*m_current_search);
-        m_current_search->SetViewMode(static_cast<Search::ViewMode>(n));
-        RestoreViewExpansion(*m_current_search);
+        // activated() also fires when the user re-selects the current mode;
+        // save/restore must not run then (restore would force-expand rows the
+        // user collapsed under a filtered or By Item view).
+        const auto mode = static_cast<Search::ViewMode>(n);
+        if (mode != m_current_search->GetViewMode()) {
+            SaveViewExpansion(*m_current_search);
+            m_current_search->SetViewMode(mode);
+            RestoreViewExpansion(*m_current_search);
+        }
         // Restoring expansion schedules a resize via the expanded/collapsed
         // signals. Also schedule one here because column contents change
         // between modes even when the expansion state does not.

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -717,6 +717,13 @@ void MainWindow::ModelViewRefresh()
 
     spdlog::trace("MainWindow::ModelViewRefresh() activing current search");
     m_current_search->Activate(m_items_manager.items());
+    ItemsModel &model = m_current_search->model();
+    ui->treeView->setSortingEnabled(false);
+    if (ui->treeView->model() != &model) {
+        ui->treeView->setModel(&model);
+    }
+    ui->treeView->header()->setSortIndicator(model.GetSortColumn(), model.GetSortOrder());
+    ui->treeView->setSortingEnabled(true);
     RestoreViewExpansion(*m_current_search);
     ScheduleResizeTreeColumns();
 
@@ -736,8 +743,8 @@ void MainWindow::ModelViewRefresh()
 
     m_tab_bar->setTabText(m_tab_bar->currentIndex(), m_current_search->GetCaption());
 
-    // Activate() rebuilds and re-sorts the model while the connections above
-    // are down, so the layoutChanged emitted during the rebuild is never
+    // The model rebuild and view-triggered re-sort happen while the connections
+    // above are down, so the layoutChanged emitted during the re-sort is never
     // seen. Reselect the current item (or clear it if it was filtered out)
     // explicitly.
     OnLayoutChanged();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -959,7 +959,7 @@ void MainWindow::NewSearch()
     m_tab_bar->addTab("+");
 
     spdlog::trace("MainWindow::NewSearch() setting current search: {}", caption);
-    m_current_search = new Search(m_buyout_manager, caption, m_filters, ui->treeView);
+    m_current_search = new Search(m_buyout_manager, caption, m_filters);
     m_current_search->SetRefreshReason(RefreshReason::TabCreated);
 
     // this can't be done in ctor because it'll call OnSearchFormChange slot

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -123,6 +123,8 @@ private slots:
 
 private:
     void ModelViewRefresh();
+    void SaveViewExpansion(Search &search);
+    void RestoreViewExpansion(Search &search);
     void ClearCurrentItem();
     void UpdateCurrentBucket();
     void UpdateCurrentItem();

--- a/tests/tst_itemsmodel.cpp
+++ b/tests/tst_itemsmodel.cpp
@@ -61,7 +61,7 @@ void ItemsModelTest::testerSurvivesRebuildModeSwitchAndSort()
 
     QTreeView view;
     std::vector<std::unique_ptr<Filter>> filters;
-    Search search(*buyoutFixture.manager, "Model", filters, &view);
+    Search search(*buyoutFixture.manager, "Model", filters);
     search.Activate(items);
     view.setModel(&search.model());
 
@@ -131,7 +131,7 @@ void ItemsModelTest::selectionSurvivesSort()
 
     QTreeView view;
     std::vector<std::unique_ptr<Filter>> filters;
-    Search search(*buyoutFixture.manager, "Model", filters, &view);
+    Search search(*buyoutFixture.manager, "Model", filters);
     search.Activate(items);
     view.setModel(&search.model());
 

--- a/tests/tst_itemsmodel.cpp
+++ b/tests/tst_itemsmodel.cpp
@@ -65,8 +65,7 @@ void ItemsModelTest::testerSurvivesRebuildModeSwitchAndSort()
     search.Activate(items);
     view.setModel(&search.model());
 
-    auto *model = qobject_cast<ItemsModel *>(view.model());
-    QVERIFY(model != nullptr);
+    auto *model = &search.model();
     QAbstractItemModelTester tester(model,
                                     QAbstractItemModelTester::FailureReportingMode::Fatal,
                                     this);
@@ -135,8 +134,7 @@ void ItemsModelTest::selectionSurvivesSort()
     search.Activate(items);
     view.setModel(&search.model());
 
-    auto *model = qobject_cast<ItemsModel *>(view.model());
-    QVERIFY(model != nullptr);
+    auto *model = &search.model();
 
     const QModelIndex bucket0 = model->index(0, 0);
     QCOMPARE(model->rowCount(bucket0), 5);

--- a/tests/tst_itemsmodel.cpp
+++ b/tests/tst_itemsmodel.cpp
@@ -139,6 +139,14 @@ void ItemsModelTest::selectionSurvivesSort()
     const QModelIndex bucket0 = model->index(0, 0);
     QCOMPARE(model->rowCount(bucket0), 5);
 
+    // Sort one way first so the opposite re-sort below is guaranteed to
+    // reorder rows regardless of fixture insertion order; a no-op sort would
+    // make the remap assertion vacuous. (Note Bucket::Sort maps the Qt order
+    // enums to arrangements invertedly — F34 — so assert on the arrangement
+    // changing, not on a specific direction.)
+    model->sort(0, Qt::DescendingOrder);
+    const QString first_before = model->index(0, 0, bucket0).data().toString();
+
     // Select rows 0-2 as one range, like a user shift-clicking three items.
     // The selection model tracks multi-row ranges with persistent indexes it
     // creates during layoutAboutToBeChanged; the model must remap them.
@@ -154,6 +162,7 @@ void ItemsModelTest::selectionSurvivesSort()
 
     // Re-sort in the opposite order; the selection should follow the items.
     model->sort(0, Qt::AscendingOrder);
+    QVERIFY(model->index(0, 0, bucket0).data().toString() != first_before);
 
     QStringList selected_after;
     for (const QModelIndex &idx : view.selectionModel()->selectedRows()) {

--- a/tests/tst_itemsmodel.cpp
+++ b/tests/tst_itemsmodel.cpp
@@ -63,6 +63,7 @@ void ItemsModelTest::testerSurvivesRebuildModeSwitchAndSort()
     std::vector<std::unique_ptr<Filter>> filters;
     Search search(*buyoutFixture.manager, "Model", filters, &view);
     search.Activate(items);
+    view.setModel(&search.model());
 
     auto *model = qobject_cast<ItemsModel *>(view.model());
     QVERIFY(model != nullptr);
@@ -132,6 +133,7 @@ void ItemsModelTest::selectionSurvivesSort()
     std::vector<std::unique_ptr<Filter>> filters;
     Search search(*buyoutFixture.manager, "Model", filters, &view);
     search.Activate(items);
+    view.setModel(&search.model());
 
     auto *model = qobject_cast<ItemsModel *>(view.model());
     QVERIFY(model != nullptr);

--- a/tests/tst_search.cpp
+++ b/tests/tst_search.cpp
@@ -2,7 +2,6 @@
 
 #include <QLineEdit>
 #include <QStringListModel>
-#include <QTreeView>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -29,7 +28,6 @@ struct SearchHarness
     QStringListModel categoryModel{GetItemCategories()};
     QStringListModel rarityModel{RaritySearchFilter::RARITY_LIST};
     std::vector<std::unique_ptr<Filter>> filters;
-    QTreeView view;
     QObject receiver;
     FilterCallbacks callbacks{
         &receiver,

--- a/tests/tst_search.cpp
+++ b/tests/tst_search.cpp
@@ -167,7 +167,7 @@ void SearchTest::bucketConstruction()
     items.push_back(makeSearchItem("alpha-item", "Alpha Bite", "Vaal Axe", firstTab));
     items.push_back(makeSearchItem("beta-item", "Beta Guard", "Copper Shield", secondTab));
 
-    Search search(*harness.buyoutFixture.manager, "All", harness.filters, &harness.view);
+    Search search(*harness.buyoutFixture.manager, "All", harness.filters);
     search.FromForm();
     search.FilterItems(items);
 
@@ -198,7 +198,7 @@ void SearchTest::nameFilterMembership()
     items.push_back(makeSearchItem("alpha-item", "Alpha Bite", "Vaal Axe", firstTab));
     items.push_back(makeSearchItem("beta-item", "Beta Guard", "Copper Shield", secondTab));
 
-    Search search(*harness.buyoutFixture.manager, "Filtered", harness.filters, &harness.view);
+    Search search(*harness.buyoutFixture.manager, "Filtered", harness.filters);
     search.FromForm();
     search.FilterItems(items);
 


### PR DESCRIPTION
## Summary

- expose the search model and expansion state as data
- move expansion persistence and view activation into `MainWindow`
- preserve the existing collapse quirks, view-triggered re-sort, and deferred F32 behavior
- update model/search tests and mark Phase 4 complete

## Verification

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (7/7 passed)
- `grep -n QTreeView src/search.h src/search.cpp` returns no matches
- manual smoke passed against the full expansion/sorting/selection behavior table with approximately 20k items across 350 tabs

## Notes

- The two intentional all-tabs-collapse behaviors are unchanged.
- F32 tab-switch state loss remains deferred to Phase 6.
- By Item remains slower than By Tab at large item counts; this is existing behavior and the observed delay was acceptable.