### PR TITLE
Fix F34: sort direction now matches the header indicator

### DIFF
--- a/docs/cleanup/findings.md
+++ b/docs/cleanup/findings.md
@@ -602,6 +602,12 @@ so it will survive the fix. The Phase 6 spec upgrade (July 2026) took it up
 as explicitly optional item 6.8 (own PR, prominent release note, drop
 freely).
 
+Fixed (July 2026, item 6.8): the two lambda branches in `Bucket::Sort` are
+swapped, so each Qt order enum produces the arrangement it names. Pinned by
+`tst_itemsmodel::sortDirectionMatchesOrder` (ascending order ⇒ ascending
+rows, descending ⇒ reversed); `selectionSurvivesSort` was direction-agnostic
+and survived unchanged.
+
 ### F21. Every `Item` stores its raw JSON — Confirmed (impact unmeasured)
 
 `Item::m_json` keeps the full JSON text of each item. With the large stash

--- a/src/bucket.cpp
+++ b/src/bucket.cpp
@@ -45,9 +45,9 @@ void Bucket::Sort(const Column &column, Qt::SortOrder order)
               end(m_items),
               [&](const std::shared_ptr<Item> &lhs, const std::shared_ptr<Item> &rhs) {
                   if (order == Qt::AscendingOrder) {
-                      return column.lt(rhs.get(), lhs.get());
-                  } else {
                       return column.lt(lhs.get(), rhs.get());
+                  } else {
+                      return column.lt(rhs.get(), lhs.get());
                   }
               });
 }

--- a/tests/tst_itemsmodel.cpp
+++ b/tests/tst_itemsmodel.cpp
@@ -4,6 +4,7 @@
 #include <QSignalSpy>
 #include <QTreeView>
 
+#include <algorithm>
 #include <memory>
 
 #include "filters/filterspec.h"
@@ -18,6 +19,7 @@ class ItemsModelTest : public QObject
 private slots:
     void testerSurvivesRebuildModeSwitchAndSort();
     void selectionSurvivesSort();
+    void sortDirectionMatchesOrder();
 };
 
 static std::shared_ptr<Item> makeModelItem(const QString &id,
@@ -140,9 +142,9 @@ void ItemsModelTest::selectionSurvivesSort()
 
     // Sort one way first so the opposite re-sort below is guaranteed to
     // reorder rows regardless of fixture insertion order; a no-op sort would
-    // make the remap assertion vacuous. (Note Bucket::Sort maps the Qt order
-    // enums to arrangements invertedly — F34 — so assert on the arrangement
-    // changing, not on a specific direction.)
+    // make the remap assertion vacuous. (This test asserts only that the
+    // arrangement changes; sortDirectionMatchesOrder pins which direction
+    // each order enum produces.)
     model->sort(0, Qt::DescendingOrder);
     const QString first_before = model->index(0, 0, bucket0).data().toString();
 
@@ -169,6 +171,46 @@ void ItemsModelTest::selectionSurvivesSort()
     }
     selected_after.sort();
     QCOMPARE(selected_after, selected_before);
+}
+
+// F34: the Qt sort-order enums must produce the arrangement they name, so
+// the header's sort indicator points the way the rows actually run.
+void ItemsModelTest::sortDirectionMatchesOrder()
+{
+    BuyoutManagerFixture buyoutFixture;
+    const ItemLocation firstTab = makeTestStashLocation("stash-a", "Alpha Tab", 0);
+    buyoutFixture.manager->SetStashTabLocations({firstTab});
+
+    Items items;
+    items.push_back(makeModelItem("alpha-2", "Zulu Bite", "Vaal Axe", firstTab));
+    items.push_back(makeModelItem("alpha-1", "Alpha Bite", "Copper Sword", firstTab));
+    items.push_back(makeModelItem("alpha-3", "Mid Bite", "Iron Hammer", firstTab));
+
+    FilterCatalog catalog({});
+    Search search(*buyoutFixture.manager, "Model", catalog);
+    search.FilterItems(items);
+    auto *model = &search.model();
+    const QModelIndex bucket0 = model->index(0, 0);
+    QCOMPARE(model->rowCount(bucket0), 3);
+
+    const auto rowNames = [&]() {
+        QStringList names;
+        for (int row = 0; row < model->rowCount(bucket0); ++row) {
+            names << model->index(row, 0, bucket0).data().toString();
+        }
+        return names;
+    };
+
+    model->sort(0, Qt::AscendingOrder);
+    const QStringList ascending = rowNames();
+    QStringList expected = ascending;
+    std::sort(expected.begin(), expected.end());
+    QCOMPARE(ascending, expected);
+
+    model->sort(0, Qt::DescendingOrder);
+    const QStringList descending = rowNames();
+    std::reverse(expected.begin(), expected.end());
+    QCOMPARE(descending, expected);
 }
 
 QTEST_MAIN(ItemsModelTest)


### PR DESCRIPTION
Phase 6 item 6.8 (`docs/cleanup/phase-6-mainwindow-slimming.md`), fixing F34.

## Root cause

`Bucket::Sort` mapped `Qt::AscendingOrder` to `column.lt(rhs, lhs)` — a descending arrangement — and `Qt::DescendingOrder` to ascending. `Column::lt` is a plain less-than, so nothing cancelled the inversion: the header's sort arrow has always pointed opposite to the actual row order.

## Fix

- Swap the two comparison branches so each order enum produces the arrangement it names.
- New pin `tst_itemsmodel::sortDirectionMatchesOrder`: ascending order ⇒ rows in ascending column-0 order, descending ⇒ reversed. Fails against the unfixed code (ascending produced Z→A).
- `selectionSurvivesSort` deliberately asserted only that a re-sort changes the arrangement, so it survives unchanged, as the spec predicted; its stale F34 comment is updated. The `tst_mainwindow` multi-selection sort pin computes its order dynamically and is unaffected.

## Release note (prominent)

- Clicking a column header now sorts in the direction the header arrow shows. **All sort directions flip relative to previous versions**, which had them inverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)