### PR TITLE
Skip no-op buyout database deletes on refresh (F52)

### DIFF
--- a/docs/cleanup/findings.md
+++ b/docs/cleanup/findings.md
@@ -76,8 +76,8 @@ for most accounts is nearly every item — and `BuyoutManager::Set`'s
 even when neither the memory map nor the database has an entry for that
 item. Net effect: one SQL DELETE (plus a debug log line) per item per
 refresh, ~17k no-op statements each time for this account. The fix shape:
-only call `removeItemBuyout` when `m_buyouts.erase` actually erased
-something. Caveat on the guard (July 17 review of PR #163): the memory
+only call `removeItemBuyout` when the map actually holds an entry for the
+item. Caveat on the guard (July 17 review of PR #163): the memory
 map does **not** strictly mirror the repo — `CompressTabBuyouts` (runs
 every refresh via `ApplyAutoTabBuyouts`) erases vanished tabs' entries
 from the map without repo deletes, and `MigrateItem` rekeys map entries
@@ -85,9 +85,20 @@ without repo writes (see F54). Both drift in the same direction — repo
 holds rows the map lacks — which is exactly the case the guard declines
 to delete, so the fix loses nothing; orphan rows persist in the DB and
 are re-erased from the map each session (accepted tradeoff, pinned by
-`clearingAbsentBuyoutSkipsRepo`). Same snapshot-cascade family as F46;
-also a hard constraint on items-pipeline M2 — the per-tab delta path must
-scope buyout propagation to the delta, not rerun this loop per tab reply.
+`clearingAbsentBuyoutSkipsRepo` / `clearingAbsentTabBuyoutSkipsRepo`).
+Second caveat (same review): erasing the map entry *before* the repo
+delete would make a failed DELETE unretryable — the guard would skip
+every later clear and the row would resurrect at the next `Load()`.
+Fixed shape: `removeItemBuyout`/`removeLocationBuyout` return success
+and the map entry is erased only afterward, so a failed delete is
+retried on the next clear (pinned by `failedDeleteKeepsEntryForRetry`).
+The save path still discards failures — `saveItemBuyout` returns bool
+but is invoked via signal connection (`application.cpp`), so a failed
+save silently drops the buyout at the next restart; accepted for now,
+noted here so the delete/save asymmetry is deliberate. Same
+snapshot-cascade family as F46; also a hard constraint on
+items-pipeline M2 — the per-tab delta path must scope buyout
+propagation to the delta, not rerun this loop per tab reply.
 Fix assigned: PR #163.
 
 ### F53. Deleted stash tabs and characters resurrect from the cache at restart — Confirmed; follow-up PR assigned

--- a/src/buyoutmanager.cpp
+++ b/src/buyoutmanager.cpp
@@ -52,12 +52,16 @@ void BuyoutManager::Set(const Item &item, const Buyout &buyout)
     }
 
     if (buyout.IsNull()) {
-        // Only touch the database when there was an entry to clear: the map
-        // mirrors the repo within a session, and PropagateTabBuyouts clears
-        // nearly every item on every refresh, which used to issue one no-op
-        // DELETE per item (F52).
-        if (m_buyouts.erase(item.id()) > 0) {
-            m_repo.removeItemBuyout(item);
+        // Only touch the database when the manager holds an entry to clear:
+        // PropagateTabBuyouts clears nearly every item on every refresh, which
+        // used to issue one no-op DELETE per item (F52). The map can drift from
+        // the repo (CompressItemBuyouts and MigrateItem drop or rekey entries
+        // in memory only), but only toward orphan repo rows, which this guard
+        // leaves alone. The map entry is erased only after a successful delete
+        // so that a failed delete is retried the next time this entry is
+        // cleared, instead of leaving the row to resurrect at the next Load().
+        if (m_buyouts.contains(item.id()) && m_repo.removeItemBuyout(item)) {
+            m_buyouts.erase(item.id());
         }
         return;
     }
@@ -116,9 +120,9 @@ void BuyoutManager::SetTab(const ItemLocation &location, const Buyout &buyout)
     }
 
     if (buyout.IsNull()) {
-        // Same no-op-delete guard as Set() (F52).
-        if (m_tab_buyouts.erase(location.id()) > 0) {
-            m_repo.removeLocationBuyout(location);
+        // Same no-op-delete guard and erase-after-success ordering as Set() (F52).
+        if (m_tab_buyouts.contains(location.id()) && m_repo.removeLocationBuyout(location)) {
+            m_tab_buyouts.erase(location.id());
         }
         return;
     }

--- a/src/buyoutmanager.cpp
+++ b/src/buyoutmanager.cpp
@@ -52,8 +52,13 @@ void BuyoutManager::Set(const Item &item, const Buyout &buyout)
     }
 
     if (buyout.IsNull()) {
-        m_repo.removeItemBuyout(item);
-        m_buyouts.erase(item.id());
+        // Only touch the database when there was an entry to clear: the map
+        // mirrors the repo within a session, and PropagateTabBuyouts clears
+        // nearly every item on every refresh, which used to issue one no-op
+        // DELETE per item (F52).
+        if (m_buyouts.erase(item.id()) > 0) {
+            m_repo.removeItemBuyout(item);
+        }
         return;
     }
 
@@ -111,8 +116,10 @@ void BuyoutManager::SetTab(const ItemLocation &location, const Buyout &buyout)
     }
 
     if (buyout.IsNull()) {
-        m_repo.removeLocationBuyout(location);
-        m_tab_buyouts.erase(location.id());
+        // Same no-op-delete guard as Set() (F52).
+        if (m_tab_buyouts.erase(location.id()) > 0) {
+            m_repo.removeLocationBuyout(location);
+        }
         return;
     }
 

--- a/src/buyoutmanager.cpp
+++ b/src/buyoutmanager.cpp
@@ -54,12 +54,14 @@ void BuyoutManager::Set(const Item &item, const Buyout &buyout)
     if (buyout.IsNull()) {
         // Only touch the database when the manager holds an entry to clear:
         // PropagateTabBuyouts clears nearly every item on every refresh, which
-        // used to issue one no-op DELETE per item (F52). The map can drift from
-        // the repo (CompressItemBuyouts and MigrateItem drop or rekey entries
-        // in memory only), but only toward orphan repo rows, which this guard
-        // leaves alone. The map entry is erased only after a successful delete
-        // so that a failed delete is retried the next time this entry is
-        // cleared, instead of leaving the row to resurrect at the next Load().
+        // used to issue one no-op DELETE per item (F52). The in-memory cleanup
+        // paths (CompressItemBuyouts, MigrateItem) drift the map from the repo
+        // only toward orphan repo rows, which this guard leaves alone; a
+        // failed save drifts the other way (map entry without a row), but
+        // clearing such an entry is just a harmless zero-row DELETE. The map
+        // entry is erased only after a successful delete so that a failed
+        // delete is retried the next time this entry is cleared, instead of
+        // leaving the row to resurrect at the next Load().
         if (m_buyouts.contains(item.id()) && m_repo.removeItemBuyout(item)) {
             m_buyouts.erase(item.id());
         }

--- a/src/datastore/buyoutrepo.cpp
+++ b/src/datastore/buyoutrepo.cpp
@@ -262,7 +262,7 @@ bool BuyoutRepo::saveLocationBuyout(const Buyout &buyout, const ItemLocation &lo
     return true;
 }
 
-void BuyoutRepo::removeItemBuyout(const Item &item)
+bool BuyoutRepo::removeItemBuyout(const Item &item)
 {
     spdlog::debug("BuyoutRepo: removing item buyout: PrettyName='{}' ({})",
                   item.PrettyName(),
@@ -271,17 +271,19 @@ void BuyoutRepo::removeItemBuyout(const Item &item)
     QSqlQuery q(m_db);
     if (!q.prepare("DELETE FROM item_buyouts WHERE item_id = :item_id")) {
         spdlog::error("BuyoutRepo: prepare() failed: {}", q.lastError().text());
-        return;
+        return false;
     }
 
     q.bindValue(":item_id", item.id());
 
     if (!q.exec()) {
         ds::logQueryError("BuyoutRepo::removeItemBuyout()", q);
+        return false;
     }
+    return true;
 }
 
-void BuyoutRepo::removeLocationBuyout(const ItemLocation &location)
+bool BuyoutRepo::removeLocationBuyout(const ItemLocation &location)
 {
     spdlog::debug("BuyoutRepo: removing location buyout: '{}' ({})",
                   location.GetHeader(),
@@ -290,12 +292,14 @@ void BuyoutRepo::removeLocationBuyout(const ItemLocation &location)
     QSqlQuery q(m_db);
     if (!q.prepare("DELETE FROM location_buyouts WHERE location_id = :location_id")) {
         spdlog::error("BuyoutRepo: prepare() failed: {}", q.lastError().text());
-        return;
+        return false;
     }
 
     q.bindValue(":location_id", location.id());
 
     if (!q.exec()) {
         ds::logQueryError("BuyoutRepo::removeLocationBuyout()", q);
+        return false;
     }
+    return true;
 }

--- a/src/datastore/buyoutrepo.h
+++ b/src/datastore/buyoutrepo.h
@@ -22,8 +22,8 @@ public:
     std::unordered_map<QString, Buyout> getItemBuyouts();
     std::unordered_map<QString, Buyout> getLocationBuyouts();
 
-    void removeItemBuyout(const Item &item);
-    void removeLocationBuyout(const ItemLocation &location);
+    bool removeItemBuyout(const Item &item);
+    bool removeLocationBuyout(const ItemLocation &location);
 
     bool resetRepo();
     bool ensureSchema();

--- a/tests/tst_buyoutmanager.cpp
+++ b/tests/tst_buyoutmanager.cpp
@@ -204,7 +204,9 @@ void BuyoutManagerTest::clearingAbsentTabBuyoutSkipsRepo()
 
 // The map entry must survive a failed repo delete so a later clear retries
 // it — otherwise the F52 guard would skip every retry and the undeleted row
-// would resurrect at the next Load().
+// would resurrect at the next Load(). A BEFORE DELETE trigger forces the
+// failure without disturbing the row, so both states are observable after
+// the failed clear and the retry deletes both for real.
 void BuyoutManagerTest::failedDeleteKeepsEntryForRetry()
 {
     BuyoutManagerFixture fixture;
@@ -213,12 +215,14 @@ void BuyoutManagerTest::failedDeleteKeepsEntryForRetry()
     fixture.manager->Set(item, makeChaosBuyout(52.0));
 
     QSqlQuery q(*fixture.db);
-    QVERIFY(q.exec("DROP TABLE item_buyouts"));
+    QVERIFY(q.exec("CREATE TRIGGER f52_block_delete BEFORE DELETE ON item_buyouts "
+                   "BEGIN SELECT RAISE(FAIL, 'f52 test: delete blocked'); END"));
 
     fixture.manager->Set(item, Buyout());
     QVERIFY(fixture.manager->Get(item).IsActive());
+    QVERIFY(fixture.repo->getItemBuyouts().contains(item.id()));
 
-    QVERIFY(fixture.repo->ensureSchema());
+    QVERIFY(q.exec("DROP TRIGGER f52_block_delete"));
 
     fixture.manager->Set(item, Buyout());
     QVERIFY(fixture.manager->Get(item).IsNull());

--- a/tests/tst_buyoutmanager.cpp
+++ b/tests/tst_buyoutmanager.cpp
@@ -1,3 +1,4 @@
+#include <QSqlQuery>
 #include <QtTest/QtTest>
 
 #include "testfixtures.h"
@@ -16,6 +17,8 @@ private slots:
     void clearingItemBuyoutRemovesRepoRow();
     void clearingTabBuyoutRemovesRepoRow();
     void clearingAbsentBuyoutSkipsRepo();
+    void clearingAbsentTabBuyoutSkipsRepo();
+    void failedDeleteKeepsEntryForRetry();
 };
 
 void BuyoutManagerTest::stringToBuyout()
@@ -183,6 +186,43 @@ void BuyoutManagerTest::clearingAbsentBuyoutSkipsRepo()
     fixture.manager->Set(item, Buyout());
 
     QVERIFY(fixture.repo->getItemBuyouts().contains(item.id()));
+}
+
+// SetTab carries the same F52 guard as Set; pin the tab side too.
+void BuyoutManagerTest::clearingAbsentTabBuyoutSkipsRepo()
+{
+    BuyoutManagerFixture fixture;
+    const ItemLocation location = makeTestStashLocation("f52-desynced-tab");
+
+    fixture.repo->saveLocationBuyout(makeChaosBuyout(52.0), location);
+    QVERIFY(fixture.manager->GetTab(location).IsNull());
+
+    fixture.manager->SetTab(location, Buyout());
+
+    QVERIFY(fixture.repo->getLocationBuyouts().contains(location.id()));
+}
+
+// The map entry must survive a failed repo delete so a later clear retries
+// it — otherwise the F52 guard would skip every retry and the undeleted row
+// would resurrect at the next Load().
+void BuyoutManagerTest::failedDeleteKeepsEntryForRetry()
+{
+    BuyoutManagerFixture fixture;
+    const Item item = makeTestItem("f52-failed-delete-item");
+
+    fixture.manager->Set(item, makeChaosBuyout(52.0));
+
+    QSqlQuery q(*fixture.db);
+    QVERIFY(q.exec("DROP TABLE item_buyouts"));
+
+    fixture.manager->Set(item, Buyout());
+    QVERIFY(fixture.manager->Get(item).IsActive());
+
+    QVERIFY(fixture.repo->ensureSchema());
+
+    fixture.manager->Set(item, Buyout());
+    QVERIFY(fixture.manager->Get(item).IsNull());
+    QVERIFY(!fixture.repo->getItemBuyouts().contains(item.id()));
 }
 
 QTEST_GUILESS_MAIN(BuyoutManagerTest)

--- a/tests/tst_buyoutmanager.cpp
+++ b/tests/tst_buyoutmanager.cpp
@@ -13,6 +13,9 @@ private slots:
     void tabBuyoutPropagation();
     void clearingItemBuyoutRemovesInMemoryValue();
     void clearingTabBuyoutRemovesInMemoryValue();
+    void clearingItemBuyoutRemovesRepoRow();
+    void clearingTabBuyoutRemovesRepoRow();
+    void clearingAbsentBuyoutSkipsRepo();
 };
 
 void BuyoutManagerTest::stringToBuyout()
@@ -133,6 +136,53 @@ void BuyoutManagerTest::clearingTabBuyoutRemovesInMemoryValue()
     fixture.manager->SetTab(location, Buyout());
 
     QVERIFY(fixture.manager->GetTab(location).IsNull());
+}
+
+// The F52 guard must not weaken the F14 behavior: clearing a buyout that
+// exists still removes the database row, not just the in-memory entry.
+void BuyoutManagerTest::clearingItemBuyoutRemovesRepoRow()
+{
+    BuyoutManagerFixture fixture;
+    const Item item = makeTestItem("f52-item");
+
+    fixture.manager->Set(item, makeChaosBuyout(52.0));
+    QVERIFY(fixture.repo->getItemBuyouts().contains(item.id()));
+
+    fixture.manager->Set(item, Buyout());
+
+    QVERIFY(!fixture.repo->getItemBuyouts().contains(item.id()));
+}
+
+void BuyoutManagerTest::clearingTabBuyoutRemovesRepoRow()
+{
+    BuyoutManagerFixture fixture;
+    const ItemLocation location = makeTestStashLocation("f52-tab");
+
+    fixture.manager->SetTab(location, makeChaosBuyout(52.0));
+    QVERIFY(fixture.repo->getLocationBuyouts().contains(location.id()));
+
+    fixture.manager->SetTab(location, Buyout());
+
+    QVERIFY(!fixture.repo->getLocationBuyouts().contains(location.id()));
+}
+
+// Clearing a buyout the manager does not hold must not touch the repo (F52:
+// PropagateTabBuyouts clears nearly every item on every refresh, which used
+// to issue one no-op DELETE per item). Pinned by seeding a row behind the
+// manager's back: with the guard, the row survives the clear. This is the
+// accepted tradeoff — a desynced row lasts until the next Load() picks it
+// up — in exchange for not running ~item-count DELETEs per refresh.
+void BuyoutManagerTest::clearingAbsentBuyoutSkipsRepo()
+{
+    BuyoutManagerFixture fixture;
+    const Item item = makeTestItem("f52-desynced-item");
+
+    fixture.repo->saveItemBuyout(makeChaosBuyout(52.0), item);
+    QVERIFY(fixture.manager->Get(item).IsNull());
+
+    fixture.manager->Set(item, Buyout());
+
+    QVERIFY(fixture.repo->getItemBuyouts().contains(item.id()));
 }
 
 QTEST_GUILESS_MAIN(BuyoutManagerTest)


### PR DESCRIPTION
## Summary

Found during items-pipeline M1 validation (see the F52 register entry on PR #162): every refresh produced ~17,250 consecutive no-op `BuyoutRepo: removing item buyout` DELETEs on an 18.5k-item account — `PropagateTabBuyouts` clears the inherited buyout of nearly every item on every `ItemsRefreshed`, and `BuyoutManager::Set`/`SetTab`'s `IsNull` branch hit the repo unconditionally.

The clear path now only issues the DELETE when the in-memory map actually holds an entry. The map does not strictly mirror the repo (`CompressTabBuyouts`/`CompressItemBuyouts` erase map entries without repo deletes, and `MigrateItem` rekeys in memory only — see F54), but those cleanup/migration paths drift only toward orphan repo rows, which is exactly the case the guard declines to delete. The known opposite drift — a failed save leaving a map entry without a row — is harmless here: clearing such an entry is a zero-row DELETE that succeeds and heals the map.

Per review, `removeItemBuyout`/`removeLocationBuyout` now return success (matching the `save*` convention) and the map entry is erased only after a successful delete — erasing first would have made a failed DELETE unretryable, letting the undeleted row resurrect at the next `Load()`. With the fixed ordering, a failed delete is retried the next time the entry is cleared.

Accepted tradeoffs, test-pinned: a row written to the repo behind the manager's back survives an in-session clear and self-heals at the next `Load()` (item and tab variants). The save path still discards failures via its signal connection — recorded in the F52 ledger entry so the asymmetry is deliberate.

Also a prerequisite constraint for items-pipeline M2: the per-tab delta path must not rerun this loop per reply, and now the loop it does run is no longer O(items) database calls.

## Test plan

- [x] `ctest` — 13/13 pass; new pins: clearing an existing buyout still removes the repo row (item and tab, the F14 behavior), clearing an absent one leaves the repo untouched (item and tab), and a failed DELETE — forced by a `BEFORE DELETE RAISE(FAIL)` trigger so the row survives — keeps both the map entry and the repo row, and the retry after the trigger is removed deletes both
- [x] Full suite green; no behavior change other than the eliminated no-op DELETEs and the failed-delete retry ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)