### PR TITLE
Phase-0 QCoro spike: destroy-while-suspended falsified, shutdown becomes detach-plus-no-delivery (S1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 /build/
 /out/
 
+# Phase-0 spike build trees (spikes/qcoro/README.md).
+/build-spike/
+/build-spike-asan/
+
 # Acquisitions installers are currently built here.
 /deploy/
 /Output/

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,12 @@ when this map and a header disagree, the header wins.
   rate-limited networking redesign (typed facade, coroutine pumps, gate).
   Records current decisions only; cites review finding IDs inline.
 - `design/network-redesign-reviews.md` — that spec's decision history:
-  review-round finding tables (ER, IR, R4–R7), round narratives,
+  review-round finding tables (ER, IR, R4–R7, S1), round narratives,
   reversal records, and the revision log.
+- `../spikes/qcoro/` — phase-0 QCoro spike (standalone CMake project,
+  not part of the acquisition build): the running-code evidence behind
+  the S1 findings. Throwaway by design; kept while the network
+  redesign is in flight.
 - `design/network-ground-truth.md` — living ledger of numbered claims
   (N1, N2, …) about how the Path of Exile API actually limits requests,
   each with cited evidence. Designs are derived from these claims.

--- a/docs/design/network-redesign-reviews.md
+++ b/docs/design/network-redesign-reviews.md
@@ -188,7 +188,7 @@ filed against phase-0/harness evidence, not re-readings.
 
 | ID | Finding | Resolution |
 |---|---|---|
-| R6-1 | Reply ownership was still contradictory: the RAII wrapper installed at await-return left the in-flight span — the reply's longest phase — ownerless; shutdown step 2 had the hub abort replies whose pointers lived only in already-destroyed frames (an implied registry the spec denied having); and `deleteLater` never runs once the event loop has stopped, so the claimed shutdown cleanup mechanism was wrong. | Wrapper installed at dispatch, before the first await — the owner is the pump frame at every instant, including suspension (destroying a suspended coroutine runs its locals' destructors; spike-verified, not assumed). The shutdown abort step is deleted: nothing aborted, nothing tracked; `abort()` is now never called anywhere. Post-loop `deleteLater` is inert; the `QNetworkAccessManager` parent (destroyed after the hub) is the documented backstop. |
+| R6-1 | Reply ownership was still contradictory: the RAII wrapper installed at await-return left the in-flight span — the reply's longest phase — ownerless; shutdown step 2 had the hub abort replies whose pointers lived only in already-destroyed frames (an implied registry the spec denied having); and `deleteLater` never runs once the event loop has stopped, so the claimed shutdown cleanup mechanism was wrong. | Wrapper installed at dispatch, before the first await — the owner is the pump frame at every instant, including suspension (destroying a suspended coroutine runs its locals' destructors; spike-verified, not assumed). The shutdown abort step is deleted: nothing aborted, nothing tracked; `abort()` is now never called anywhere. Post-loop `deleteLater` is inert; the `QNetworkAccessManager` parent (destroyed after the hub) is the documented backstop. *(The locals'-destructors premise was falsified by the spike — handle destruction detaches the frame and the wrapper never runs at shutdown; QNAM parent cleanup is the sole shutdown mechanism. The dispatch-time wrapper survives as the live-session owner. S1-1/S1-3.)* |
 | R6-2 | Shutdown step 1 said `Shop` destroys "its task handles," but Shop has no tasks in this design; and `PoeApiClient` had no specified owner. | `Shop` stays callback-style: a context-bound `.then(this, …)` continuation that Qt discards on context destruction — the future equivalent of today's `this`-context connection (`shop.cpp:199`). `PoeApiClient` is a `UserSession` member declared after `rate_limiter` (destroyed after all consumers, before the limiter); its parse continuations capture values only, never the facade. |
 | R6-3 | Policy mutation and response classification disagreed: D3 updated the policy from any Full matching landed reply, while D8 reached the total parse only on clean 2xx — leaving 429s, 403/500s, and 2xx-plus-transport-error ambiguous for pacing state, which would drift stale across non-2xx runs (today's code updates on every headered reply; N25: the server counts every exchange). | Observation separated from classification (D3/D8): header parsing is attempted independently on every landed response and Full + matching updates pacing; classification stays status/network-driven and decides only the caller's outcome; missing/malformed headers become `Protocol` only where the reply would otherwise be a clean 2xx success. |
 
@@ -315,11 +315,37 @@ AddressSanitizer; leak accounting confirmed with macOS `leaks`.
   coroutine completion is the synchronous re-entrancy path; QFuture
   boundaries are the queued ones — relevant to D5/D6 stack-depth
   reasoning.
-- **S1-10 (FetchContent hygiene confirmed):**
-  `QCORO_BUILD_EXAMPLES=OFF` and `QCORO_BUILD_TESTING=OFF` (with
-  `BUILD_TESTING` off for the subproject) build no examples and
-  register no QCoro tests with CTest; the configure-time feature
-  summary reports both disabled.
+- **S1-10 (FetchContent hygiene confirmed; sharpened by Tom's
+  review):** `QCORO_BUILD_EXAMPLES=OFF` and `QCORO_BUILD_TESTING=OFF`
+  build no examples and register no QCoro tests with CTest, **with
+  the parent's `BUILD_TESTING` left ON** — QCoro maps
+  `QCORO_BUILD_TESTING` onto a directory-scoped `BUILD_TESTING` of
+  its own, so the host's flag must not be forced (the spike's first
+  cut forced it globally, which would have disabled acquisition's
+  entire test suite if copied into the root project; caught in
+  review, the checked-in reference now enables testing in the parent
+  and verifies zero QCoro tests are registered).
+
+**S1 follow-up (Tom's review of the spike round, same day).** Four
+corrections: (1) three spec clauses still stated the falsified
+mechanism — D3's reply-ownership bullet ("destroying a suspended
+coroutine runs the destructors of its in-scope locals"), the
+manager-harness reply-ownership pin ("task destruction mid-flight —
+the dispatch-time wrapper releases it"), and the integration
+shutdown pin ("resumes nothing and leaks nothing") — all rewritten
+around live-session RAII versus shutdown-time QNAM parent cleanup
+and the bounded detached-frame leak; (2) the shutdown analog now
+also **destroys the unfinished `QPromise`s** the way the hub's deque
+entries die (Tom verified the edge externally on Qt 6.11.1 first):
+futures cancel, `.then` chains do not run, detached awaiters stay
+suspended — and the same destruction mid-session would be ER1's
+resume-into-`result()` hazard, which is why D2 confines
+unfinished-promise death to post-loop shutdown; (3) the S1-10
+CMake flag correction above; (4) leak-accounting honesty: the
+in-process sentinels are authoritative — `leaks` reports the reply
+frame as a root but the timer/future frames remain *reachable* from
+Qt thread-data (pending cancel call-out events, timer
+registrations), so the tool undercounts by design.
 
 The 2,000-tab batch measurement — the other half of phasing step 0 —
 remains open.
@@ -468,4 +494,10 @@ remains open.
   silent unawaited exceptions and the sweep (S1-8), synchronous task
   completion cascades (S1-9), FetchContent hygiene (S1-10). Spike
   code lives in `spikes/qcoro/`; the 2,000-tab measurement remains
-  open.
+  open. Same-day follow-up from Tom's review: three leftover spec
+  clauses still stating the falsified mechanism rewritten (D3
+  reply ownership, two testing-plan pins), the shutdown analog
+  extended to destroy unfinished promises (futures cancel, `.then`
+  chains break, detached awaiters stay suspended), and the S1-10
+  guidance corrected — QCoro's flags only, never the global
+  `BUILD_TESTING`.

--- a/docs/design/network-redesign-reviews.md
+++ b/docs/design/network-redesign-reviews.md
@@ -237,6 +237,93 @@ qualify.
   for the captured, saturated policies; Q4's classification risk is
   independent and stands (D3, D8).
 
+## Phase-0 QCoro spike (round S1) — July 19, 2026
+
+First evidence round after the freeze, from running code rather than
+re-reading: a standalone spike (`spikes/qcoro/`, QCoro pinned at
+v0.13.0, Qt 6.11.1) exercised the spec's phasing-step-0 question
+list. Ten findings; one falsifies the shutdown *mechanism* (the
+shutdown *conclusion* survives by a different route), the rest
+confirm premises or sharpen contracts. Verified plain and under
+AddressSanitizer; leak accounting confirmed with macOS `leaks`.
+
+- **S1-1 (falsifies R5-2's mechanism — spec shutdown section
+  rewritten):** destroying a `QCoro::Task` handle while its
+  coroutine is suspended does **not** destroy the frame. QCoro 0.13
+  tasks are reference-counted: the promise holds its own reference
+  until `final_suspend`, the handle holds a second. Handle
+  destruction *detaches* — the frame survives, frame locals'
+  destructors do **not** run (R6-1's premise), and the coroutine
+  resumes normally if its awaited event is later delivered (verified
+  for timer, `QFuture`, and `QNetworkReply` awaitables). A detached
+  coroutine that runs to completion self-destroys at
+  `final_suspend`; one that never resumes is leaked. QCoro has no
+  API to destroy a suspended coroutine from outside.
+- **S1-2 (shutdown conclusion survives via no-delivery):** all three
+  awaiters resume only through the event loop — the reply awaiter
+  connects `finished` with `Qt::QueuedConnection` to a context
+  object owned by the frame, the `QFuture` awaiter resumes through
+  `QFutureWatcher` event delivery, and timer awaits ride timer
+  events. The shutdown-analog experiment (handles destroyed while
+  suspended, then owners destroyed including a `QNAM` with an
+  in-flight reply, with **no** further loop iterations) resumed
+  nothing and did not crash. Cost: detached frames and their locals
+  leak at process exit — a few hundred bytes per frame
+  (`leaks`-verified) — acceptable, the process is exiting.
+- **S1-3 (R6-1's reply release corrected):** because the frame is
+  not destroyed at shutdown, the dispatch-time RAII wrapper never
+  runs there; `QNetworkAccessManager` parent cleanup is the **only**
+  shutdown reply cleanup, not a backstop. The wrapper still owns the
+  reply on every live-session path (observed releasing the reply via
+  `deleteLater` when a detached frame completed).
+- **S1-4 (handle destruction is never cancellation):** mid-session,
+  destroying a suspended task's handle detaches it and a later event
+  resumes it while the loop runs — destroying handles neither stops
+  nor cancels anything. D2's stop-token-only rule and D6's
+  "abort never destroys live handles" + completed-only sweep are
+  therefore load-bearing for lifetime, not merely stylistic; owners
+  must never be destroyed while their suspended tasks could still be
+  resumed by a live loop.
+- **S1-5 (queued resumption verified, R4-2):**
+  `QPromise::finish()` returns before the awaiter resumes — the
+  `QFuture` awaiter delivers through the loop, so promise completion
+  never re-enters synchronously. The stop-interruptible sleep
+  prototype (QPromise + `std::stop_callback` posting a queued
+  completion) delivered the full D2 contract: `request_stop()`
+  returned before resumption, ~22 ms wake versus a 5 s sleep,
+  pre-stopped tokens complete without suspending, undisturbed sleeps
+  complete normally. `std::stop_callback` itself runs synchronously
+  inside `request_stop()` — the queued indirection is mandatory.
+- **S1-6 (ready awaits are synchronous):** `co_await` on a finished
+  future does not suspend — the continuation runs inline in the
+  caller, as does contextless `QFuture::then` on a finished future.
+  Confirms the initialize-before-launch premise (IR2, D6).
+- **S1-7 (move-out path):** `co_await qCoro(future).takeResult()`
+  produced 0 copies / 3 moves; plain `co_await future` copies
+  (`QFuture::result()`). The worker's single-consumer payload path
+  should use `takeResult()` (D6).
+- **S1-8 (R5-1 premises confirmed):** an unawaited task's exception
+  is stored in the promise and vanishes silently when the handle
+  dies — no terminate, no log; awaiting rethrows. Root-coroutine
+  catch-alls stay mandatory. Destroying a completed task's handle
+  from inside its own completion cascade did not fault (ASAN-clean;
+  `final_suspend` resumes awaiters before dropping its own
+  reference) — the deferred sweep remains the defensive choice.
+- **S1-9 (completion cascades are synchronous):** a completing task
+  resumes its awaiting coroutines directly on the completing stack
+  (`TaskFinalSuspend`, source- and E10-verified). Coroutine-to-
+  coroutine completion is the synchronous re-entrancy path; QFuture
+  boundaries are the queued ones — relevant to D5/D6 stack-depth
+  reasoning.
+- **S1-10 (FetchContent hygiene confirmed):**
+  `QCORO_BUILD_EXAMPLES=OFF` and `QCORO_BUILD_TESTING=OFF` (with
+  `BUILD_TESTING` off for the subproject) build no examples and
+  register no QCoro tests with CTest; the configure-time feature
+  summary reports both disabled.
+
+The 2,000-tab batch measurement — the other half of phasing step 0 —
+remains open.
+
 ## Revision log
 
 - **July 18, 2026** — drafted; open items reviewed with Tom and
@@ -365,3 +452,20 @@ qualify.
   an inactivity bound; "empirically exact" scoped to the captured
   policies. Bar for any further paper finding: a false statement or
   a missing harness-needed contract.
+- **July 19, 2026 (phase-0 spike, round S1 — rev. 8)** — first
+  running-code evidence round. S1-1 falsified R5-2's
+  destroy-while-suspended mechanism (QCoro tasks are refcounted;
+  handle destruction detaches, locals' destructors do not run, a
+  detached frame resumes if its event is later delivered). The
+  shutdown section was rewritten around **detach plus no delivery**:
+  every awaiter resumes only via the event loop, so post-`exec()`
+  destruction resumes nothing; detached frames leak a few hundred
+  bytes each at process exit; QNAM parent cleanup is the only
+  shutdown reply cleanup (S1-2, S1-3). Handle destruction is never
+  cancellation (S1-4). All other spike-verified premises held:
+  queued stop wakeups and the sleep primitive (S1-5), synchronous
+  ready-future continuation (S1-6), `takeResult()` move-out (S1-7),
+  silent unawaited exceptions and the sweep (S1-8), synchronous task
+  completion cascades (S1-9), FetchContent hygiene (S1-10). Spike
+  code lives in `spikes/qcoro/`; the 2,000-tab measurement remains
+  open.

--- a/docs/design/network-redesign-reviews.md
+++ b/docs/design/network-redesign-reviews.md
@@ -245,7 +245,9 @@ v0.13.0, Qt 6.11.1) exercised the spec's phasing-step-0 question
 list. Ten findings; one falsifies the shutdown *mechanism* (the
 shutdown *conclusion* survives by a different route), the rest
 confirm premises or sharpen contracts. Verified plain and under
-AddressSanitizer; leak accounting confirmed with macOS `leaks`.
+AddressSanitizer; the spike's in-process sentinel checks are the
+authoritative leak accounting, with macOS `leaks` as a cross-check
+on the subset it can root (see the second follow-up below).
 
 - **S1-1 (falsifies R5-2's mechanism — spec shutdown section
   rewritten):** destroying a `QCoro::Task` handle while its
@@ -342,10 +344,34 @@ suspended — and the same destruction mid-session would be ER1's
 resume-into-`result()` hazard, which is why D2 confines
 unfinished-promise death to post-loop shutdown; (3) the S1-10
 CMake flag correction above; (4) leak-accounting honesty: the
-in-process sentinels are authoritative — `leaks` reports the reply
-frame as a root but the timer/future frames remain *reachable* from
-Qt thread-data (pending cancel call-out events, timer
-registrations), so the tool undercounts by design.
+in-process sentinels are authoritative — `leaks` cannot see
+everything (details corrected in the second follow-up below).
+
+**S1 second follow-up (external review, same day).** Four more
+corrections: (1) the integration leak criterion was **impossible as
+written** — it demanded that no promise shared state leak with a
+detached frame, but QCoro's `QFuture` awaiter stores a `QFuture`
+inside the frame, so the shared state is necessarily retained while
+the frame leaks; the pin now specifies the bounded **transitive
+closure** of the detached frames (frame + awaiter objects + watcher
+and context QObjects + retained future handles and their shared
+state + sleep timers) with replies and independently owned objects
+explicitly outside it. (2) The shutdown analog previously discarded
+the `.then` child future unawaited — production's worker awaits
+`.then(parse)`'s **child**, not the parent; E8 now builds exactly
+that topology (parent → parse continuation → child future → detached
+awaiter suspended on the child) and pins that promise death cancels
+the whole chain without running parse or resuming the child's
+awaiter. (3) The leak-tool description contradicted the output:
+observed on Qt 6.11.1/macOS, the reply frame is a stable root, the
+**timer frames surface as root cycles**, and only the future frames
+stay hidden behind Qt thread-data reachability (pending cancel
+call-outs) — and the rooted set varies between runs, so the
+sentinels remain the count and `leaks` is a cross-check on its
+rooted subset. (4) D3 lifecycle wording: the reply wrapper's local
+unwinds when the coroutine **body** completes; the frame
+*allocation* lingers until the retained handle is swept (D6) — the
+two events were previously conflated.
 
 The 2,000-tab batch measurement — the other half of phasing step 0 —
 remains open.
@@ -500,4 +526,10 @@ remains open.
   extended to destroy unfinished promises (futures cancel, `.then`
   chains break, detached awaiters stay suspended), and the S1-10
   guidance corrected — QCoro's flags only, never the global
-  `BUILD_TESTING`.
+  `BUILD_TESTING`. A second follow-up (external review, same day)
+  replaced the impossible no-shared-state leak criterion with the
+  transitive-closure bound, gave E8 the production chained-future
+  topology (worker awaits `.then(parse)`'s child), matched the
+  leak-tool description to its actual output, and separated
+  body-completion local unwinding from frame-allocation reclamation
+  in D3.

--- a/docs/design/network-redesign-reviews.md
+++ b/docs/design/network-redesign-reviews.md
@@ -373,6 +373,20 @@ unwinds when the coroutine **body** completes; the frame
 *allocation* lingers until the retained handle is swept (D6) — the
 two events were previously conflated.
 
+**S1 third follow-up (external review, same day).** Two refinements
+to the E8 chain pin: the chain awaiter now uses the worker's actual
+production await — `co_await qCoro(future).takeResult()`, which runs
+as its own inner QCoro task frame — instead of a plain `co_await`;
+and the child future's terminal state is asserted directly
+(`isCanceled() && isFinished()` hold synchronously after promise
+destruction, no event loop involved) rather than inferred from the
+absence of parsing/resumption, with main's own child-future copy
+released before leak accounting so only the detached frames retain
+its shared state. Frame arithmetic corrected everywhere: seven
+coroutine frame allocations leak — five top-level task frames (E6a +
+four E8) plus the two inner task frames (`QCoro::sleepFor`'s,
+`qCoro().takeResult()`'s).
+
 The 2,000-tab batch measurement — the other half of phasing step 0 —
 remains open.
 

--- a/docs/design/network-redesign.md
+++ b/docs/design/network-redesign.md
@@ -1,19 +1,26 @@
 # Network Redesign: Typed Facade, Coroutine Pumps, and the Gate
 
-**Status: ACCEPTED July 19, 2026 (revision 7) — frozen for
-implementation.** Drafted July 18 and reviewed through six rounds in
-two days, plus one post-freeze errata batch (rev 7: eight
-corrections and contract completions, all shrinking — R7 in the
-review history). The review process converged (later rounds found
-contradictions among earlier fixes and resolved them by deletion),
-so further findings are filed against phase-0/harness evidence, not
-re-readings; any further paper finding must show a false statement
-or a missing harness-needed contract. The finding tables (ER, IR,
-R4-\*, R5-\*, R6-\*, R7), the round narratives, the reversal
-records, and the revision log live in `network-redesign-reviews.md`;
-this spec records only current decisions and cites finding IDs
-inline where a decision's shape came from a review. No code has been
-written against this spec.
+**Status: ACCEPTED July 19, 2026 (revision 8) — frozen for
+implementation; phase-0 spike executed.** Drafted July 18 and
+reviewed through six rounds in two days, plus one post-freeze errata
+batch (rev 7: eight corrections and contract completions, all
+shrinking — R7 in the review history). The review process converged
+(later rounds found contradictions among earlier fixes and resolved
+them by deletion), so further findings are filed against
+phase-0/harness evidence, not re-readings; any further paper finding
+must show a false statement or a missing harness-needed contract.
+Rev 8 is the first such evidence round: the phase-0 QCoro spike
+(round S1, code in `spikes/qcoro/`) falsified R5-2's
+destroy-while-suspended mechanism — QCoro task handles detach, not
+destroy — and the shutdown section now rests on
+detach-plus-no-delivery (S1-1..S1-4); every other spike-tested
+premise held (S1-5..S1-10). The finding tables (ER, IR, R4-\*,
+R5-\*, R6-\*, R7, S1), the round narratives, the reversal records,
+and the revision log live in `network-redesign-reviews.md`; this
+spec records only current decisions and cites finding IDs inline
+where a decision's shape came from a review. No production code has
+been written against this spec; the spike is throwaway evidence, not
+production code.
 
 This document specifies the redesign of acquisition's rate-limited
 networking: how the items worker, the rate limiter, and the network
@@ -195,7 +202,19 @@ hazard is unconstructible:
   and worker coroutine onto the current stack — exactly the unbounded
   re-entrancy D5's complete-promise-last rule exists to avoid. The
   stop-interruptible sleep and the gate implement wake-on-stop as a
-  queued resume; verified by the phase-0 spike.
+  queued resume; spike-verified (S1-5): `std::stop_callback` runs
+  synchronously inside `request_stop()`, the queued indirection
+  delivers the contract, and QCoro's `QFuture` awaiter itself
+  resumes through the event loop (`QFutureWatcher`), so promise
+  completion never re-enters an awaiter synchronously. (Completion
+  of a *task* awaited by another coroutine, by contrast, resumes the
+  awaiter synchronously on the completing stack — S1-9.)
+- **Destroying a task handle is never cancellation (S1-4):** QCoro
+  0.13 task handles are shared references, not owners — destroying
+  one while the coroutine is suspended *detaches* the frame, which
+  survives and resumes normally when its awaited event is delivered
+  (see the shutdown section). The stop token is the only cancellation
+  channel; handle sweeps destroy completed tasks only (D6).
 - **In-flight requests are never `QNetworkReply::abort()`ed by
   cancellation.** The server has already counted an in-flight request
   (N25: state headers are post-increment, 1:1); aborting it would
@@ -205,11 +224,12 @@ hazard is unconstructible:
   is recorded in history and capture (a 429 still records its
   violation — D3), and then completes `Canceled`. **`abort()` is
   never called at all (R6-1):** its one remaining purpose — waking
-  awaiters at shutdown — vanished when R5-2 made shutdown destroy
-  the awaiters first. At shutdown a still-in-flight reply is
-  released by its owning frame's destruction (D3's dispatch-time
-  wrapper) and finally cleaned up by its `QNetworkAccessManager`
-  parent.
+  awaiters at shutdown — vanished when R5-2 made shutdown stop
+  delivering events to the awaiters. At shutdown a still-in-flight
+  reply is cleaned up by its `QNetworkAccessManager` parent — the
+  only shutdown cleanup, since the owning frame is detached, not
+  destroyed, and its RAII wrapper never runs there (S1-3); the
+  wrapper owns the reply on every live-session path.
 - **No future retention** (resolves ER5): the
   worker does not keep a registry of outstanding futures — the
   stop_source is the abort handle. Each per-fetch coroutine holds its
@@ -598,7 +618,10 @@ forum and login traffic as-is, documented here.
   frame it is running in, and **abort never destroys live handles**
   — rev 4's released-on-abort rule contradicted D2's
   stragglers-resolve-later contract; stragglers finish `Canceled`
-  (bounded by the transfer timeout) and are then swept. No
+  (bounded by the transfer timeout) and are then swept. The sweep
+  destroys **completed** tasks only — destroying a suspended task's
+  handle would detach it, not stop it (S1-1/S1-4), and the frame
+  would still resume later while the loop runs. No
   incremental per-completion reclamation beyond that sweep until the
   measurement demands it. "Update done" remains completion counting:
   each per-fetch coroutine increments its counter after its await
@@ -618,14 +641,18 @@ forum and login traffic as-is, documented here.
   must not mutate state that now belongs to a later update. Each
   per-fetch coroutine has essentially one await site, so the check
   surface is small; pinned with ready-future tests.
-- **Initialize-before-launch invariant (IR2):** Qt runs `.then`
-  continuations synchronously when attached to an already-finished
-  future, and QCoro resumes without suspending on ready futures — so
-  a fail-fast submission (setup cooldown, shutdown) can run
-  completion logic *during the batch-submit loop*. All per-update
-  counters and batch state are initialized before the first
-  submission is made. Pinned with ready-success and ready-error
-  futures.
+- **Initialize-before-launch invariant (IR2; spike-verified S1-6):**
+  Qt runs `.then` continuations synchronously when attached to an
+  already-finished future, and QCoro resumes without suspending on
+  ready futures — so a fail-fast submission (setup cooldown,
+  shutdown) can run completion logic *during the batch-submit loop*.
+  All per-update counters and batch state are initialized before the
+  first submission is made. Pinned with ready-success and
+  ready-error futures.
+- **Payload extraction (S1-7):** the worker's single-consumer path
+  moves the parsed payload out with `co_await
+  qCoro(future).takeResult()` (0 copies, spike-measured); plain
+  `co_await future` copies via `QFuture::result()`.
 - Failure semantics at the update level are unchanged from M1: a
   terminal failure aborts the update (`request_stop()` on the update's
   stop_source, no emit); atomic per-reply replacement already
@@ -802,9 +829,11 @@ R7), message. F50's diagnostics rewording rides along here.
 ## Shutdown and task ownership
 
 Added July 18, 2026 (ER4); rewritten in the IR round (IR3, IR4);
-**rewritten again July 19 (R5-2): the asynchronous teardown
-choreography is deleted.** Rev 4 required queued resumptions and a
-live event loop during shutdown — but `Application` is destroyed
+rewritten July 19 (R5-2: the asynchronous teardown choreography is
+deleted); **mechanism corrected by the phase-0 spike (S1-1..S1-4):
+shutdown safety comes from detach-plus-no-delivery, not from
+destroying suspended frames.** Rev 4 required queued resumptions and
+a live event loop during shutdown — but `Application` is destroyed
 after `a.exec()` returns (`src/main.cpp`), when the loop is already
 gone, and `UserSession`'s member order destroys `Shop` and
 `ItemsManagerWorker` *before* `RateLimiter` (`src/application.h`), so
@@ -812,6 +841,16 @@ a hub-driven drain of worker tasks was unreachable. Rather than build
 an asynchronous shutdown subsystem for consumers that are already
 destroyed, shutdown is now **destruction order, not choreography** —
 which the existing member order already implements.
+
+**What destroying a task handle actually does (S1-1):** QCoro 0.13
+tasks are reference-counted — the promise holds its own reference
+until `final_suspend`, the handle holds a second. Destroying the
+handle of a suspended coroutine *detaches* it: the frame survives,
+its locals' destructors do not run, and it resumes normally if its
+awaited event is later delivered, self-destroying at completion.
+There is no API to destroy a suspended coroutine from outside.
+Handle ownership therefore controls the lifetime of *completed*
+frames only; it neither cancels nor stops a live one (D2).
 
 **Ownership chain:** the hub owns the gate and the pumps; each pump
 owns its deque and its drain-task handle (a member — never
@@ -828,41 +867,56 @@ existed solely for the deleted choreography).
    `ItemsManagerWorker`, with the facade following (R6-2), still
    ahead of the hub. `Shop` has no tasks — its context-bound
    continuation dies with it (D7, R6-2). The worker destroys its
-   task handles **while suspended** — a destroyed coroutine never
-   resumes, so no awaiter outlives this step. Within each
-   destructor, task handles are destroyed before any member they
-   might observe.
-2. The hub dies next: its destructor destroys every drain task and
-   setup task (while suspended — nothing resumes into a dying pump).
-   Destroying a frame runs its locals' destructors, which releases
-   that task's in-flight reply through the dispatch-time RAII
-   wrapper (D3, R6-1); post-loop `deleteLater` is inert, and the
-   reply's `QNetworkAccessManager` parent — destroyed after the hub
-   — is the documented backstop. **Nothing is `abort()`ed and the
-   hub tracks no in-flight replies** (R6-1 deleted the abort step:
-   its only purpose was waking awaiters, which no longer exist by
-   this point). Pumps and the gate are destroyed last.
+   task handles: completed frames are destroyed outright, suspended
+   frames are **detached** (S1-1). Neither ever resumes, because
+   nothing delivers events after `a.exec()` returns — see below.
+   Within each destructor, task handles are destroyed before any
+   member they might observe.
+2. The hub dies next: its destructor destroys every drain-task and
+   setup-task handle (detaching any suspended frame — nothing
+   resumes into a dying pump). A still-in-flight reply is cleaned up
+   by its `QNetworkAccessManager` parent, destroyed after the hub —
+   the **only** shutdown reply cleanup (S1-3): the detached frame's
+   dispatch-time RAII wrapper never runs, and post-loop `deleteLater`
+   is inert anyway. **Nothing is `abort()`ed and the hub tracks no
+   in-flight replies** (R6-1 deleted the abort step: its only
+   purpose was waking awaiters, which nothing can resume by this
+   point). Pumps and the gate are destroyed last.
 3. Promises die unfinished, **safely by construction**: the
-   every-future-finishes guarantee (D1/D2) exists for live awaiters,
-   and steps 1–2 guarantee none exists — every consumer coroutine is
-   destroyed before the promise it awaited. `.then()` continuations
-   on broken promises do not run (Qt cancels the chain).
+   every-future-finishes guarantee (D1/D2) exists for awaiters that
+   can still resume, and steps 1–2 plus the dead loop guarantee none
+   can — every consumer coroutine is completed-and-destroyed or
+   detached-and-undeliverable before the promise it awaited dies.
+   `.then()` continuations on broken promises do not run (Qt cancels
+   the chain).
 
-This works identically whether the event loop is alive or not —
-destruction is synchronous and depends on no event delivery. **QCoro
-0.13's destroy-while-suspended semantics are load-bearing here, not
-a fallback:** the phase-0 spike must verify destruction while
-suspended on each awaitable we use (future, reply, timer, gate) and
-that a destroyed task's reply-awaiter connection dies with it — a
-later `finished` emission resumes nothing.
+**Why nothing resumes (S1-2):** every awaiter we use delivers
+resumption only through the event loop — the reply awaiter connects
+`finished` via `Qt::QueuedConnection` to a context object owned by
+the frame, the `QFuture` awaiter resumes through `QFutureWatcher`
+event delivery, the timer awaiter rides timer events, and the gate
+and stop-interruptible sleep are built on the `QFuture` path (D5).
+After `a.exec()` returns no loop iteration ever runs, so a detached
+frame is inert no matter what signals fire during destruction —
+spike-verified for the full analog (handles destroyed while
+suspended on timer/future/reply, then QNAM destroyed with an
+in-flight reply: nothing resumed, nothing crashed). The cost is
+bounded and accepted: each detached frame plus its locals leaks a
+few hundred bytes at process exit. Consequently **this shutdown is
+only valid after the event loop has stopped** — destroying owners
+while the loop still runs would let detached frames resume into
+freed memory. No live-session path destroys owners (the invariant
+below), and `Application` teardown runs after `a.exec()` returns.
 
 **Invariant: no coroutine resumes through a destroyed `this`.**
 During a live session the invariant holds because owners (hub,
 worker) outlive their tasks and no live-session path destroys them;
-at shutdown every suspension point (sleep, gate, reply, future) is
-destroyed while suspended and never resumed — which is why QCoro ≥
-0.13 is a hard floor: it fixed the leak when a task is destroyed
-while awaiting a `QFuture`.
+at shutdown it holds because nothing delivers a resumption once the
+loop has stopped (S1-2). QCoro ≥ 0.13 stays a hard floor: the
+`QFuture` awaiter's `QFutureWatcher` lives inside the frame
+(spike-verified at 0.13), so a completed-and-destroyed frame can
+never be resumed by a later finish, and the FetchContent
+include-path fix landed in 0.13; earlier releases are unverified.
 
 **Exception policy (IR4; rewritten R5-1).** Boundary payloads are
 `expected`, so an exception crossing a layer boundary is a bug — but
@@ -925,14 +979,20 @@ replaced by the drain loop.
   release). Requires Qt ≥ 6.8 — satisfied by our 6.11 floor; MIT
   license. Used for: awaiting `QFuture`/`QNetworkReply`/timers,
   `QCoro::Task<>` in the worker and pumps. **0.13 is a hard floor, not
-  a preference**: it fixed a memory leak when a task is destroyed
-  while awaiting a `QFuture`, which the shutdown contract leans on.
+  a preference**: the semantics the shutdown contract leans on —
+  the `QFuture` awaiter's `QFutureWatcher` living inside the frame,
+  queued reply-awaiter delivery, refcounted detach behavior — are
+  spike-verified at 0.13 exactly (S1); earlier releases are
+  unverified, and the FetchContent include-path fix landed in 0.13.
   (The spec's first draft said 0.11.x was current — stale; caught by
   ER9.)
-- **FetchContent hygiene (IR round):** QCoro's examples default ON
-  and its tests inherit `BUILD_TESTING`, which acquisition enables
-  globally — both must be disabled explicitly in the FetchContent
-  configuration.
+- **FetchContent hygiene (IR round; spike-verified S1-10):** QCoro's
+  examples default ON and its tests inherit `BUILD_TESTING`, which
+  acquisition enables globally — both must be disabled explicitly in
+  the FetchContent configuration (`QCORO_BUILD_EXAMPLES=OFF`,
+  `QCORO_BUILD_TESTING=OFF`, and `BUILD_TESTING` forced off for the
+  subproject; the spike's `spikes/qcoro/CMakeLists.txt` is the
+  working reference).
 - Qt has **no native** `QFuture` coroutine support as of 6.11; an
   upstreaming effort exists targeting 6.12 at the earliest. If it
   lands, the future-awaiting uses of QCoro can migrate; the
@@ -1070,29 +1130,26 @@ sleep.)
 ## Phasing sketch (an implementation plan derives from this)
 
 0. **QCoro integration spike (IR round; gates everything
-   QCoro-dependent).** A throwaway target exercising: task-handle
-   ownership and destruction while suspended on each awaitable we use
-   (future, reply, timer); awaiting already-finished futures;
-   `result()` vs `takeResult()` on the single-consumer path (the
-   worker should move the parsed payload out, not copy a stash
-   wrapper); synchronous promise-completion re-entrancy; stopped
-   waits; queued-vs-synchronous resumption on stop (R4-2 requires
-   queued; `abort()` no longer exists anywhere, R6-1);
-   **destroy-while-suspended as the shutdown
-   mechanism (R5-2)** — destruction while suspended on each awaitable,
-   with no live event loop, that a destroyed task's reply-awaiter
-   connection dies with it (a later `finished` emission resumes
-   nothing), and **that destroying a suspended frame runs its
-   locals' destructors** (R6-1's reply-release mechanism — verify,
-   don't assume); task destruction from inside its own continuation vs a
-   deferred sweep (R5-1); the stored-exception behavior of an
-   unawaited task (confirming R5-1's premise). Plus the FetchContent hygiene flags (QCoro examples off,
-   tests out of our CTest). Findings feed back into D2/D6/shutdown
-   before any production code. **Alongside it, one measurement:**
-   batch submission at the 2,000-tab scale the items-pipeline doc
-   names — peak memory and abort cost for the full
-   promise/future/frame/token population. Measure first; bounded
-   flow control is speculative machinery until numbers demand it.
+   QCoro-dependent). Executed July 19, 2026** — code in
+   `spikes/qcoro/` (a standalone CMake project, not part of the
+   acquisition build), findings recorded as round S1 in the review
+   history and folded into D2, D6, the shutdown section, and the
+   dependency section in the same commit. The question list it
+   exercised: task-handle ownership and destruction while suspended
+   on each awaitable we use (future, reply, timer); awaiting
+   already-finished futures; `result()` vs `takeResult()`;
+   promise-completion re-entrancy; stopped waits;
+   queued-vs-synchronous resumption on stop; destroy-while-suspended
+   as the shutdown mechanism; continuation self-destruction vs the
+   deferred sweep; unawaited-task exceptions; the FetchContent
+   hygiene flags. Headline result: R5-2's mechanism was falsified
+   (handle destruction detaches, S1-1) and the shutdown contract now
+   rests on detach-plus-no-delivery (S1-2); everything else held.
+   **Still open from this step, one measurement:** batch submission
+   at the 2,000-tab scale the items-pipeline doc names — peak memory
+   and abort cost for the full promise/future/frame/token
+   population. Measure first; bounded flow control is speculative
+   machinery until numbers demand it.
 1. Manager test harness against current code (no behavior change).
 2. QCoro dependency + primitives (stop-interruptible sleep, gate)
    with their tests.

--- a/docs/design/network-redesign.md
+++ b/docs/design/network-redesign.md
@@ -350,20 +350,21 @@ server counted them all, N25).
   must not be re-created one level down. The RAII wrapper (a
   `deleteLater` deleter) is installed **at dispatch, before the
   first await** — dispatch and await are separate steps — making the
-  wrapper a local in the pump's frame. The owner is therefore the
-  frame at every instant, *including suspension*: destroying a
-  suspended coroutine runs the destructors of its in-scope locals,
-  so task destruction at shutdown releases the reply with no other
-  mechanism, no registry, and no abort. Body copied and headers
-  consumed before any completion or retry decision. Every path —
-  success, error, each retry attempt, exception (composes with the
-  completion guard), cancellation-after-landing, task destruction —
+  wrapper a local in the pump's frame. The frame owns the reply on
+  **every live-session path**, including through suspension: the
+  wrapper runs whenever the frame is destroyed, which happens at
+  completion (normal, error, exception, cancellation-after-landing).
+  At shutdown the frame is *detached*, not destroyed (S1-1), so the
+  wrapper never runs there — the reply's `QNetworkAccessManager`
+  parent, destroyed after the hub, is the sole shutdown cleanup
+  (S1-3); still no registry and no abort. Body copied and headers
+  consumed before any completion or retry decision. Every
+  live-session path — success, error, each retry attempt, exception
+  (composes with the completion guard), cancellation-after-landing —
   cleans up through that one wrapper; no per-path deletion code.
-  After the event loop has stopped, `deleteLater` is inert; the
-  reply's `QNetworkAccessManager` parent (destroyed after the hub)
-  is the documented backstop. The gate permit observes `finished`
-  but never owns or deletes the reply. The setup path owns its HEAD
-  reply under the same rule (D4).
+  The gate permit observes `finished` but never owns or deletes the
+  reply. The setup path owns its HEAD reply under the same rule
+  (D4).
 - Retries are bounded (`MAX_ATTEMPTS = 3`) so a systemically broken
   policy cannot hammer the API — each 429 still increments the violation
   counter and logs (N10: layer-4 goodwill is finite).
@@ -987,12 +988,15 @@ replaced by the drain loop.
   (The spec's first draft said 0.11.x was current — stale; caught by
   ER9.)
 - **FetchContent hygiene (IR round; spike-verified S1-10):** QCoro's
-  examples default ON and its tests inherit `BUILD_TESTING`, which
-  acquisition enables globally — both must be disabled explicitly in
-  the FetchContent configuration (`QCORO_BUILD_EXAMPLES=OFF`,
-  `QCORO_BUILD_TESTING=OFF`, and `BUILD_TESTING` forced off for the
-  subproject; the spike's `spikes/qcoro/CMakeLists.txt` is the
-  working reference).
+  examples default ON and its tests follow `BUILD_TESTING`, which
+  acquisition enables globally — set `QCORO_BUILD_EXAMPLES=OFF` and
+  `QCORO_BUILD_TESTING=OFF`, and **do not touch the global
+  `BUILD_TESTING`** (that would disable acquisition's own test
+  suite; QCoro maps `QCORO_BUILD_TESTING` onto a directory-scoped
+  `BUILD_TESTING` of its own, so the parent's flag stays intact).
+  The spike's `spikes/qcoro/CMakeLists.txt` is the working
+  reference: it enables testing in the parent and verifies `ctest`
+  lists zero QCoro tests.
 - Qt has **no native** `QFuture` coroutine support as of 6.11; an
   upstreaming effort exists targeting 6.12 at the earliest. If it
   lands, the future-awaiting uses of QCoro can migrate; the
@@ -1051,12 +1055,14 @@ sleep.)
    *value*, never an exceptional future; **permit-free retry
    (R4-1)**: a retrying entry holds no permit during its retry sleep
    — a sibling pump acquires the gate and sends while that sleep
-   runs; **reply ownership (R5-4/R6-1)**: every reply the fake sender
-   hands out is destroyed exactly once on every path — success,
-   non-retryable error, each retry attempt, cancel-after-landing,
-   drain exception, and task destruction mid-flight (the
-   dispatch-time wrapper releases it) — leak and double-deletion
-   pins; **observation (R6-3)**: a 429 and a 500 carrying Full
+   runs; **reply ownership (R5-4/R6-1; corrected S1)**: every reply
+   the fake sender hands out is destroyed exactly once on every
+   live-session path — success, non-retryable error, each retry
+   attempt, cancel-after-landing, drain exception — via the
+   dispatch-time wrapper when the frame completes; destroying a
+   task handle mid-flight detaches the frame (S1-1), which still
+   completes when the reply lands and releases it through the same
+   wrapper — leak and double-deletion pins; **observation (R6-3)**: a 429 and a 500 carrying Full
    matching headers update the policy while completing their
    status-driven outcomes, and a 2xx-plus-transport-error updates
    from its headers and completes `Network`.
@@ -1114,15 +1120,21 @@ sleep.)
    context-bound `Shop` continuation does not run after `Shop` is
    destroyed.
 6. **Integration coverage** (group 4 + IR3; shutdown pins rewritten
-   R5-2): cancellation races across layers (abort mid-pacing-sleep,
-   mid-gate-wait, mid-flight); **destruction reaches every
-   suspension** — destroying worker-then-hub in the `UserSession`
-   member order while a pump is mid-pacing-sleep, mid-retry-sleep,
-   mid-gate-wait, and mid-flight resumes nothing and leaks nothing
-   (leak-checked; promises may die unfinished — no awaiter exists to
-   observe them); destruction mid-update; completed-future retention
-   (memory does not grow with completed fetches across a long
-   update).
+   R5-2, corrected S1): cancellation races across layers (abort
+   mid-pacing-sleep, mid-gate-wait, mid-flight); **destruction
+   reaches every suspension** — destroying worker-then-hub in the
+   `UserSession` member order, with no further event-loop
+   iterations, while a pump is mid-pacing-sleep, mid-retry-sleep,
+   mid-gate-wait, and mid-flight resumes nothing and crashes
+   nothing; suspended frames detach and leak by design (S1-1/S1-2)
+   — the leak check pins that the leak is *bounded to the detached
+   frames* and that no reply, promise shared state, or owner
+   object leaks with them; promises die unfinished — no awaiter can
+   be resumed to observe them, and destroying an unfinished
+   `QPromise` cancels its future without resuming its detached
+   awaiter or running `.then` continuations; destruction
+   mid-update; completed-future retention (memory does not grow
+   with completed fetches across a long update).
 7. Every commit compiles and passes `ctest` (working rule #2). The
    capture instrument's tests (`tst_networkcapture.cpp`) must keep
    passing — captures are live research data (Q5, Q9).

--- a/docs/design/network-redesign.md
+++ b/docs/design/network-redesign.md
@@ -352,8 +352,10 @@ server counted them all, N25).
   first await** — dispatch and await are separate steps — making the
   wrapper a local in the pump's frame. The frame owns the reply on
   **every live-session path**, including through suspension: the
-  wrapper runs whenever the frame is destroyed, which happens at
-  completion (normal, error, exception, cancellation-after-landing).
+  wrapper runs when the coroutine body completes and its locals
+  unwind (normal, error, exception, cancellation-after-landing) —
+  the frame *allocation* itself lingers until the retained handle
+  is swept (D6), but its locals are already gone by then.
   At shutdown the frame is *detached*, not destroyed (S1-1), so the
   wrapper never runs there — the reply's `QNetworkAccessManager`
   parent, destroyed after the hub, is the sole shutdown cleanup
@@ -1127,14 +1129,23 @@ sleep.)
    iterations, while a pump is mid-pacing-sleep, mid-retry-sleep,
    mid-gate-wait, and mid-flight resumes nothing and crashes
    nothing; suspended frames detach and leak by design (S1-1/S1-2)
-   — the leak check pins that the leak is *bounded to the detached
-   frames* and that no reply, promise shared state, or owner
-   object leaks with them; promises die unfinished — no awaiter can
-   be resumed to observe them, and destroying an unfinished
-   `QPromise` cancels its future without resuming its detached
-   awaiter or running `.then` continuations; destruction
-   mid-update; completed-future retention (memory does not grow
-   with completed fetches across a long update).
+   — the leak check pins that the leak is bounded to the **transitive
+   closure of the detached frames**: the frame allocations plus what
+   only they retain (the awaiter objects, their `QFutureWatcher` and
+   context QObjects, retained `QFuture` handles — which necessarily
+   keep their promise shared state alive, since QCoro's awaiter
+   stores a `QFuture` inside the frame — and sleep timers). Outside
+   that closure nothing may leak: not a reply (the QNAM parent must
+   free it), not an owner object (hub, pump, worker, facade
+   members), not anything reachable other than through a detached
+   frame; promises die unfinished — no awaiter can be resumed to
+   observe them, and destroying an unfinished `QPromise` cancels
+   its future and its `.then` chain without running a parse
+   continuation or resuming the detached awaiter of the chained
+   child future (the production topology: the worker awaits
+   `.then(parse)`'s child, not the parent — S1 follow-up 2);
+   destruction mid-update; completed-future retention (memory does
+   not grow with completed fetches across a long update).
 7. Every commit compiles and passes `ctest` (working rule #2). The
    capture instrument's tests (`tst_networkcapture.cpp`) must keep
    passing — captures are live research data (Q5, Q9).

--- a/spikes/qcoro/CMakeLists.txt
+++ b/spikes/qcoro/CMakeLists.txt
@@ -1,0 +1,55 @@
+# Phase-0 QCoro integration spike (network-redesign spec, phasing step 0).
+#
+# Standalone throwaway project — NOT part of the acquisition build.
+# Configure separately:
+#   cmake -S spikes/qcoro -B build-spike -DCMAKE_PREFIX_PATH=$HOME/Qt/6.11.1/macos
+#   cmake --build build-spike
+#   ./build-spike/qcoro_spike
+#
+# Exercises the spec's spike question list: destroy-while-suspended on each
+# awaitable, queued-vs-synchronous resumption, unawaited-task exceptions,
+# result() vs takeResult(), promise-completion re-entrancy, and the
+# FetchContent hygiene flags below (QCoro examples off, its tests out of CTest).
+
+cmake_minimum_required(VERSION 3.28)
+project(qcoro_spike LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+
+find_package(Qt6 6.8 REQUIRED COMPONENTS Core Network)
+
+include(FetchContent)
+
+# FetchContent hygiene (spec "Dependency: QCoro"): QCoro's examples default ON
+# and its tests inherit BUILD_TESTING, which acquisition enables globally.
+# Both must be forced off. The spike verifies these are the right knobs.
+set(QCORO_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(QCORO_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+set(QCORO_WITH_QTDBUS OFF CACHE BOOL "" FORCE)
+set(QCORO_WITH_QTWEBSOCKETS OFF CACHE BOOL "" FORCE)
+set(QCORO_WITH_QTQUICK OFF CACHE BOOL "" FORCE)
+set(QCORO_WITH_QML OFF CACHE BOOL "" FORCE)
+
+FetchContent_Declare(
+    qcoro
+    GIT_REPOSITORY https://github.com/qcoro/qcoro.git
+    GIT_TAG        v0.13.0
+)
+FetchContent_MakeAvailable(qcoro)
+
+add_executable(qcoro_spike main.cpp)
+target_link_libraries(qcoro_spike PRIVATE
+    Qt6::Core
+    Qt6::Network
+    QCoro6::Core
+    QCoro6::Network
+)
+
+option(SPIKE_ASAN "Build the spike with AddressSanitizer" OFF)
+if(SPIKE_ASAN)
+    target_compile_options(qcoro_spike PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+    target_link_options(qcoro_spike PRIVATE -fsanitize=address)
+endif()

--- a/spikes/qcoro/CMakeLists.txt
+++ b/spikes/qcoro/CMakeLists.txt
@@ -20,14 +20,22 @@ set(CMAKE_AUTOMOC ON)
 
 find_package(Qt6 6.8 REQUIRED COMPONENTS Core Network)
 
+# Reproduce acquisition's situation: the root project enables testing
+# globally (BUILD_TESTING=ON). The QCORO_* flags below must keep QCoro's
+# tests and examples out WITHOUT touching the parent's BUILD_TESTING —
+# forcing the global flag off here would disable the host project's own
+# test suite when this file is used as the integration reference.
+include(CTest)
+
 include(FetchContent)
 
-# FetchContent hygiene (spec "Dependency: QCoro"): QCoro's examples default ON
-# and its tests inherit BUILD_TESTING, which acquisition enables globally.
-# Both must be forced off. The spike verifies these are the right knobs.
+# FetchContent hygiene (spec "Dependency: QCoro"): QCoro's examples default
+# ON, and its tests follow BUILD_TESTING unless QCORO_BUILD_TESTING is set —
+# QCoro maps QCORO_BUILD_TESTING onto a directory-scoped BUILD_TESTING of its
+# own, so the parent's flag stays untouched. Verified: with BUILD_TESTING=ON
+# in the parent, `ctest -N` lists zero QCoro tests and no examples build.
 set(QCORO_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(QCORO_BUILD_TESTING OFF CACHE BOOL "" FORCE)
-set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 set(QCORO_WITH_QTDBUS OFF CACHE BOOL "" FORCE)
 set(QCORO_WITH_QTWEBSOCKETS OFF CACHE BOOL "" FORCE)
 set(QCORO_WITH_QTQUICK OFF CACHE BOOL "" FORCE)

--- a/spikes/qcoro/README.md
+++ b/spikes/qcoro/README.md
@@ -1,0 +1,33 @@
+# Phase-0 QCoro spike
+
+Running-code evidence for the network-redesign spec's phasing step 0
+(`docs/design/network-redesign.md`). Findings are recorded as review
+round **S1** in `docs/design/network-redesign-reviews.md`; the spec's
+D2/D6/shutdown/dependency sections cite them inline.
+
+Standalone throwaway project — not part of the acquisition build.
+
+```sh
+cmake -S spikes/qcoro -B build-spike -DCMAKE_PREFIX_PATH=$HOME/Qt/6.11.1/macos
+cmake --build build-spike
+./build-spike/qcoro_spike            # exit code = number of failed CHECKs
+```
+
+Optional verification passes:
+
+```sh
+cmake -S spikes/qcoro -B build-spike-asan -DSPIKE_ASAN=ON \
+      -DCMAKE_PREFIX_PATH=$HOME/Qt/6.11.1/macos
+cmake --build build-spike-asan && ./build-spike-asan/qcoro_spike
+leaks --atExit -- ./build-spike/qcoro_spike   # macOS leak accounting
+```
+
+The binary prints CHECK lines (internal validity of each experiment)
+and FINDING lines (the observed QCoro v0.13.0 semantics). Four frame
+leaks at exit are deliberate — they demonstrate S1-1/S1-2's
+detached-frame behavior.
+
+Headline result (S1-1): destroying a `QCoro::Task` handle while the
+coroutine is suspended does **not** destroy the frame — it detaches
+it. Shutdown safety comes from queued awaiter delivery plus the dead
+event loop, not from frame destruction.

--- a/spikes/qcoro/README.md
+++ b/spikes/qcoro/README.md
@@ -23,9 +23,11 @@ leaks --atExit -- ./build-spike/qcoro_spike   # macOS leak accounting
 ```
 
 The binary prints CHECK lines (internal validity of each experiment)
-and FINDING lines (the observed QCoro v0.13.0 semantics). Five
-detached-frame leaks at exit are deliberate — they demonstrate
-S1-1/S1-2's detach behavior, and each frame transitively retains its
+and FINDING lines (the observed QCoro v0.13.0 semantics). Seven
+deliberate coroutine-frame leaks remain at exit — five top-level
+task frames (E6a + four E8 tasks) plus two inner task frames
+(`QCoro::sleepFor`'s and `qCoro().takeResult()`'s) — demonstrating
+S1-1/S1-2's detach behavior; each frame transitively retains its
 awaiter state (`QFutureWatcher`, context QObjects, `QFuture` handles
 keeping promise shared state alive, sleep timers). The in-process
 sentinel checks are the authoritative leak accounting; what `leaks`

--- a/spikes/qcoro/README.md
+++ b/spikes/qcoro/README.md
@@ -23,9 +23,13 @@ leaks --atExit -- ./build-spike/qcoro_spike   # macOS leak accounting
 ```
 
 The binary prints CHECK lines (internal validity of each experiment)
-and FINDING lines (the observed QCoro v0.13.0 semantics). Four frame
-leaks at exit are deliberate — they demonstrate S1-1/S1-2's
-detached-frame behavior.
+and FINDING lines (the observed QCoro v0.13.0 semantics). Four
+detached-frame leaks at exit are deliberate — they demonstrate
+S1-1/S1-2's detach behavior. The in-process sentinel checks are the
+authoritative leak accounting: `leaks` reports the reply frame as a
+root but the timer/future frames remain *reachable* from Qt
+thread-data (pending cancel call-out events, timer registrations),
+so it undercounts by design, not by error.
 
 Headline result (S1-1): destroying a `QCoro::Task` handle while the
 coroutine is suspended does **not** destroy the frame — it detaches

--- a/spikes/qcoro/README.md
+++ b/spikes/qcoro/README.md
@@ -23,13 +23,17 @@ leaks --atExit -- ./build-spike/qcoro_spike   # macOS leak accounting
 ```
 
 The binary prints CHECK lines (internal validity of each experiment)
-and FINDING lines (the observed QCoro v0.13.0 semantics). Four
+and FINDING lines (the observed QCoro v0.13.0 semantics). Five
 detached-frame leaks at exit are deliberate — they demonstrate
-S1-1/S1-2's detach behavior. The in-process sentinel checks are the
-authoritative leak accounting: `leaks` reports the reply frame as a
-root but the timer/future frames remain *reachable* from Qt
-thread-data (pending cancel call-out events, timer registrations),
-so it undercounts by design, not by error.
+S1-1/S1-2's detach behavior, and each frame transitively retains its
+awaiter state (`QFutureWatcher`, context QObjects, `QFuture` handles
+keeping promise shared state alive, sleep timers). The in-process
+sentinel checks are the authoritative leak accounting; what `leaks`
+roots varies by run: the reply frame is a stable root, the timer
+frames surface as root cycles, and the future frames usually stay
+hidden behind Qt thread-data reachability (pending cancel call-out
+events). Treat the tool as a cross-check on the rooted subset, not
+as the count.
 
 Headline result (S1-1): destroying a `QCoro::Task` handle while the
 coroutine is suspended does **not** destroy the frame — it detaches

--- a/spikes/qcoro/main.cpp
+++ b/spikes/qcoro/main.cpp
@@ -1,0 +1,641 @@
+// Phase-0 QCoro integration spike (network-redesign spec, phasing step 0).
+//
+// Empirically verifies (or falsifies) the QCoro v0.13.0 semantics the frozen
+// spec relies on. Each experiment prints CHECK lines (internal validity of the
+// experiment itself — a failed CHECK means the experiment is broken) and
+// FINDING lines (the observed semantics, phrased as facts). Spec impact is
+// analyzed in docs/design/ — this binary only reports what happens.
+//
+// Exit code: number of failed CHECKs (0 = every experiment ran as designed).
+
+#include <QCoroTask>
+#include <QCoroFuture>
+#include <QCoroTimer>
+#include <QCoroNetworkReply>
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QFuture>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QPointer>
+#include <QPromise>
+#include <QTcpServer>
+#include <QTimer>
+#include <QUrl>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <stop_token>
+
+using namespace std::chrono_literals;
+
+static int g_checkFailures = 0;
+
+static void check(bool ok, const char* what) {
+    std::printf("  %s CHECK   %s\n", ok ? "[ok]" : "[!!]", what);
+    if (!ok) {
+        ++g_checkFailures;
+    }
+}
+
+static void finding(const char* what) {
+    std::printf("  ==== FINDING %s\n", what);
+}
+
+static void section(const char* name) {
+    std::printf("\n[%s]\n", name);
+}
+
+// Process events for roughly `ms` milliseconds.
+static void spin(int ms) {
+    QEventLoop loop;
+    QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+// Frame-local RAII sentinel: proves whether a suspended frame's locals'
+// destructors ran (the R6-1 reply-release mechanism the spec leans on).
+struct Sentinel {
+    explicit Sentinel(bool* flag) : m_flag(flag) {}
+    Sentinel(const Sentinel&) = delete;
+    Sentinel& operator=(const Sentinel&) = delete;
+    ~Sentinel() { *m_flag = true; }
+private:
+    bool* m_flag;
+};
+
+// Copy/move-counting payload for the result() vs takeResult() experiment.
+struct Counted {
+    static inline int copies = 0;
+    static inline int moves = 0;
+    static void reset() { copies = 0; moves = 0; }
+    int v = 0;
+    Counted() = default;
+    explicit Counted(int x) : v(x) {}
+    Counted(const Counted& o) : v(o.v) { ++copies; }
+    Counted(Counted&& o) noexcept : v(o.v) { ++moves; }
+    Counted& operator=(const Counted& o) { v = o.v; ++copies; return *this; }
+    Counted& operator=(Counted&& o) noexcept { v = o.v; ++moves; return *this; }
+};
+
+// ---------------------------------------------------------------------------
+// E1: awaiting an already-finished QFuture — does the coroutine suspend at all?
+// (Worker initialize-before-launch invariant: continuations on ready futures
+// run synchronously.)
+// ---------------------------------------------------------------------------
+
+struct E1State {
+    bool resumed = false;
+    int value = 0;
+};
+
+static QCoro::Task<> e1_awaitReady(E1State* s) {
+    QFuture<int> f = QtFuture::makeReadyValueFuture(42);
+    s->value = co_await f;
+    s->resumed = true;
+}
+
+static void e1() {
+    section("E1: co_await on an already-finished QFuture");
+    E1State s;
+    auto t = e1_awaitReady(&s);
+    check(s.resumed && s.value == 42, "coroutine ran to completion during the call, no event loop involved");
+    check(t.isReady(), "task handle reports ready immediately");
+    if (s.resumed) {
+        finding("awaiting a finished future never suspends: continuation runs synchronously inside the call");
+    } else {
+        finding("awaiting a finished future SUSPENDS (needs the event loop to resume)");
+    }
+
+    bool thenRan = false;
+    QFuture<int> f = QtFuture::makeReadyValueFuture(1);
+    auto f2 = f.then([&thenRan](int) { thenRan = true; });
+    check(f2.isFinished(), "contextless .then chain on a finished future is itself finished");
+    if (thenRan) {
+        finding("QFuture::then (no context) on a finished future runs the continuation synchronously");
+    } else {
+        finding("QFuture::then (no context) on a finished future did NOT run synchronously");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// E2: promise-completion re-entrancy — does finishing a QPromise resume the
+// suspended awaiter synchronously on the finishing stack, or queued?
+// (R4-2 requires queued stop wakeups; D5's complete-promise-last rule exists
+// to bound re-entrancy if this is synchronous.)
+// ---------------------------------------------------------------------------
+
+struct E2State {
+    std::atomic<bool> insideFinish{false};
+    bool resumedInsideFinish = false;
+    bool resumed = false;
+};
+
+static QCoro::Task<> e2_await(E2State* s, QFuture<int> f) {
+    co_await f;
+    s->resumedInsideFinish = s->insideFinish.load();
+    s->resumed = true;
+}
+
+static void e2() {
+    section("E2: resumption when a QPromise finishes while a coroutine is suspended on its future");
+    E2State s;
+    QPromise<int> p;
+    p.start();
+    auto t = e2_await(&s, p.future());
+    check(!s.resumed, "coroutine is suspended on the unfinished future");
+    s.insideFinish = true;
+    p.addResult(7);
+    p.finish();
+    s.insideFinish = false;
+    const bool resumedSynchronously = s.resumed;
+    spin(50);
+    check(s.resumed, "coroutine resumed once events were processed");
+    if (resumedSynchronously || s.resumedInsideFinish) {
+        finding("QPromise::finish() resumed the awaiter SYNCHRONOUSLY on the finishing stack");
+    } else {
+        finding("QPromise::finish() returned before the awaiter resumed — QCoro's QFuture awaiter delivers "
+                "resumption through the event loop (QFutureWatcher), i.e. queued");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// E3: result() vs takeResult() on the single-consumer path — copy/move counts.
+// ---------------------------------------------------------------------------
+
+struct E3State {
+    int value = 0;
+    bool done = false;
+};
+
+static QCoro::Task<> e3_direct(E3State* s, QFuture<Counted> f) {
+    Counted c = co_await f;
+    s->value = c.v;
+    s->done = true;
+}
+
+static QCoro::Task<> e3_take(E3State* s, QFuture<Counted> f) {
+    Counted c = co_await qCoro(f).takeResult();
+    s->value = c.v;
+    s->done = true;
+}
+
+static QFuture<Counted> e3_makeReady(int v) {
+    QPromise<Counted> p;
+    p.start();
+    p.addResult(Counted(v));
+    p.finish();
+    return p.future();
+}
+
+static void e3() {
+    section("E3: result() vs takeResult() on the single-consumer path");
+    {
+        QFuture<Counted> f = e3_makeReady(5);
+        Counted::reset();
+        E3State s;
+        auto t = e3_direct(&s, f);
+        check(s.done && s.value == 5, "direct co_await returned the payload");
+        std::printf("       plain `co_await future`:            %d copies, %d moves\n", Counted::copies, Counted::moves);
+        check(Counted::copies >= 1, "plain co_await copies the payload out of the future (QFuture::result())");
+    }
+    {
+        QFuture<Counted> f = e3_makeReady(6);
+        Counted::reset();
+        E3State s;
+        auto t = e3_take(&s, f);
+        check(s.done && s.value == 6, "takeResult co_await returned the payload");
+        std::printf("       `co_await qCoro(f).takeResult()`:   %d copies, %d moves\n", Counted::copies, Counted::moves);
+        check(Counted::copies == 0, "takeResult path performs no copies (moves only)");
+        finding("qCoro(future).takeResult() is the move-out path for the worker's single-consumer payloads");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// E4: stop-interruptible sleep prototype — the primitive D2 requires: wakes on
+// stop, resumption queued (request_stop() returns before the sleeper resumes).
+// ---------------------------------------------------------------------------
+
+struct SleepShared {
+    QPromise<bool> p;
+    std::atomic_flag fired = ATOMIC_FLAG_INIT;
+    void complete(bool stopped) {
+        if (!fired.test_and_set()) {
+            p.addResult(stopped);
+            p.finish();
+        }
+    }
+};
+
+// Returns true if woken by stop, false if the full duration elapsed.
+static QCoro::Task<bool> stopSleep(std::chrono::milliseconds ms, std::stop_token tok, QObject* ctx) {
+    if (tok.stop_requested()) {
+        co_return true;  // checkpoint: a pre-stopped wait never suspends
+    }
+    auto st = std::make_shared<SleepShared>();
+    st->p.start();
+    QFuture<bool> f = st->p.future();
+    QTimer::singleShot(ms, ctx, [st] { st->complete(false); });
+    std::stop_callback cb(tok, [st, ctx] {
+        // Queued on purpose: R4-2 forbids resuming coroutines on the
+        // request_stop() stack.
+        QMetaObject::invokeMethod(ctx, [st] { st->complete(true); }, Qt::QueuedConnection);
+    });
+    const bool stopped = co_await f;
+    co_return stopped;
+}
+
+struct E4State {
+    std::atomic<bool> insideRequestStop{false};
+    bool resumedInsideRequestStop = false;
+    bool stopped = false;
+    bool done = false;
+    qint64 elapsedMs = 0;
+};
+
+static QCoro::Task<> e4_run(E4State* s, std::chrono::milliseconds ms, std::stop_token tok, QObject* ctx) {
+    QElapsedTimer timer;
+    timer.start();
+    s->stopped = co_await stopSleep(ms, tok, ctx);
+    s->elapsedMs = timer.elapsed();
+    s->resumedInsideRequestStop = s->insideRequestStop.load();
+    s->done = true;
+}
+
+static void e4() {
+    section("E4: stop-interruptible sleep primitive (queued wake on stop)");
+    QObject ctx;
+
+    // a) stop interrupts a long sleep
+    {
+        std::stop_source src;
+        E4State s;
+        auto t = e4_run(&s, 5000ms, src.get_token(), &ctx);
+        spin(20);
+        check(!s.done, "5s sleep still suspended after 20ms");
+        s.insideRequestStop = true;
+        src.request_stop();
+        s.insideRequestStop = false;
+        const bool resumedDuringRequestStop = s.done;
+        spin(100);
+        check(s.done && s.stopped, "sleeper woke promptly and reported 'stopped'");
+        check(!resumedDuringRequestStop && !s.resumedInsideRequestStop,
+              "request_stop() returned before the sleeper resumed (queued wakeup, R4-2)");
+        check(s.elapsedMs < 1000, "wake latency far below the 5s sleep duration");
+        std::printf("       stop wake latency: ~%lldms after request_stop()\n", static_cast<long long>(s.elapsedMs));
+    }
+
+    // b) undisturbed sleep completes normally
+    {
+        std::stop_source src;
+        E4State s;
+        auto t = e4_run(&s, 50ms, src.get_token(), &ctx);
+        spin(200);
+        check(s.done && !s.stopped, "undisturbed 50ms sleep completed normally");
+    }
+
+    // c) pre-stopped token: never suspends
+    {
+        std::stop_source src;
+        src.request_stop();
+        E4State s;
+        auto t = e4_run(&s, 5000ms, src.get_token(), &ctx);
+        check(s.done && s.stopped, "sleep with an already-stopped token completed synchronously (checkpoint)");
+    }
+    finding("a stop-interruptible sleep built on QPromise + queued stop_callback delivers R4-2's contract");
+}
+
+// ---------------------------------------------------------------------------
+// E5: destroying the Task handle while suspended on a timer — destroy or
+// detach? THE load-bearing question for the spec's shutdown-by-destruction
+// (R5-2/R6-1).
+// ---------------------------------------------------------------------------
+
+struct E5State {
+    bool localDestroyed = false;
+    bool resumed = false;
+};
+
+static QCoro::Task<> e5_sleeper(E5State* s, std::chrono::milliseconds duration) {
+    Sentinel guard(&s->localDestroyed);
+    co_await QCoro::sleepFor(duration);
+    s->resumed = true;
+}
+
+static void e5() {
+    section("E5: destroy Task handle while suspended on a timer");
+    E5State s;
+    {
+        auto t = e5_sleeper(&s, 100ms);
+        check(!t.isReady(), "sleeper is suspended");
+    }  // Task handle destroyed here, coroutine still suspended
+    const bool destroyedWithHandle = s.localDestroyed;
+    if (destroyedWithHandle) {
+        finding("destroying the Task handle destroyed the suspended frame (locals' destructors ran)");
+    } else {
+        finding("destroying the Task handle mid-suspend DETACHES the coroutine: the frame survives and "
+                "frame locals' destructors do NOT run (falsifies R5-2/R6-1's mechanism)");
+    }
+    spin(300);
+    if (s.resumed) {
+        finding("the detached coroutine RESUMED when its timer later fired — a destroyed handle does not "
+                "prevent resumption while an event loop still runs");
+    }
+    check(s.localDestroyed, "frame was destroyed by the end of the experiment (either with the handle, or at completion)");
+    if (!destroyedWithHandle && s.resumed && s.localDestroyed) {
+        finding("a detached coroutine that runs to completion self-destroys at final_suspend (refcount drops to 0)");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// E6: same question for the QFuture awaitable; plus the never-completed case
+// (frame leak) checked at the end of main.
+// ---------------------------------------------------------------------------
+
+struct E6State {
+    bool localDestroyed = false;
+    bool resumed = false;
+};
+
+static QCoro::Task<> e6_awaiter(E6State* s, QFuture<int> f) {
+    Sentinel guard(&s->localDestroyed);
+    co_await f;
+    s->resumed = true;
+}
+
+// E6a state is global: the never-finished frame is deliberately leaked and
+// re-checked at the end of main.
+static E6State g_e6a;
+static QPromise<int>* g_e6aPromise = nullptr;
+
+static void e6() {
+    section("E6: destroy Task handle while suspended on a QFuture");
+
+    // a) promise never finishes, no live handle: what happens to the frame?
+    g_e6aPromise = new QPromise<int>();
+    g_e6aPromise->start();
+    {
+        auto t = e6_awaiter(&g_e6a, g_e6aPromise->future());
+    }
+    if (!g_e6a.localDestroyed) {
+        finding("with the handle destroyed and the future never finishing, the suspended frame is LEAKED — "
+                "QCoro 0.13 has no way to destroy a suspended detached coroutine from outside");
+    } else {
+        finding("frame was destroyed with the handle despite the pending future");
+    }
+
+    // b) finishing the promise after the handle died: does the frame resume?
+    E6State s;
+    QPromise<int> p;
+    p.start();
+    {
+        auto t = e6_awaiter(&s, p.future());
+    }
+    check(!s.localDestroyed, "frame detached (matches E5)");
+    p.addResult(1);
+    p.finish();
+    spin(50);
+    if (s.resumed) {
+        finding("finishing the future after the handle was destroyed RESUMED the detached coroutine "
+                "(QFutureWatcher lives in the frame, so it survives handle destruction)");
+    }
+    check(s.localDestroyed, "detached frame self-destroyed after completing");
+}
+
+// ---------------------------------------------------------------------------
+// E7: the QNetworkReply awaitable — detach, later finished emission, and the
+// dispatch-time RAII reply wrapper (D3).
+// ---------------------------------------------------------------------------
+
+struct E7State {
+    bool localDestroyed = false;
+    bool resumed = false;
+    QPointer<QNetworkReply> reply;
+};
+
+static QCoro::Task<> e7_fetch(E7State* s, QNetworkAccessManager* nam, QUrl url) {
+    QNetworkReply* r = nam->get(QNetworkRequest(url));
+    s->reply = r;
+    // D3's dispatch-time RAII wrapper, one level down: the frame owns the reply.
+    struct ReplyReleaser {
+        QNetworkReply* r;
+        ~ReplyReleaser() { r->deleteLater(); }
+    } releaser{r};
+    Sentinel guard(&s->localDestroyed);
+    co_await r;
+    s->resumed = true;
+}
+
+static void e7(QNetworkAccessManager* nam, const QUrl& silentUrl) {
+    section("E7: destroy Task handle while suspended on an in-flight QNetworkReply");
+    E7State s;
+    {
+        auto t = e7_fetch(&s, nam, silentUrl);
+        spin(100);  // let the request reach the silent server: genuinely in-flight
+        check(!t.isReady() && !s.reply.isNull() && !s.reply->isFinished(), "reply is in-flight, coroutine suspended");
+    }
+    check(!s.localDestroyed, "frame detached, so the RAII reply wrapper did NOT run at handle destruction");
+    check(!s.reply.isNull(), "reply still alive (owned by the detached frame's wrapper + QNAM parent)");
+    s.reply->abort();  // force a finished emission after the handle is gone
+    const bool resumedDuringAbort = s.resumed;
+    spin(50);
+    check(!resumedDuringAbort, "abort()'s finished emission did not resume the coroutine synchronously (queued connection)");
+    if (s.resumed) {
+        finding("a finished emission after handle destruction RESUMED the detached coroutine via its still-live "
+                "queued connection — handle destruction does NOT sever the reply-awaiter connection");
+    }
+    check(s.localDestroyed, "detached frame self-destroyed after completing; RAII wrapper released the reply");
+    spin(50);  // let deleteLater run
+    check(s.reply.isNull(), "reply deleted via the wrapper's deleteLater once the loop spun");
+}
+
+// ---------------------------------------------------------------------------
+// E8 (run last, after all event processing has ceased): the post-exec shutdown
+// analog — tasks suspended on timer/future/reply, handles destroyed, owners
+// destroyed, and NO further event-loop iterations. This is exactly the world
+// after a.exec() returns.
+// ---------------------------------------------------------------------------
+
+static E5State g_e8Timer;
+static E6State g_e8Future;
+static E7State g_e8Reply;
+static QPromise<int>* g_e8Promise = nullptr;
+
+static void e8_setup(QNetworkAccessManager* nam, const QUrl& silentUrl) {
+    section("E8: post-exec shutdown analog (no further event processing after this point)");
+    {
+        // Duration far beyond the setup spin below — the timer must still be
+        // pending when the handles are destroyed, even under sanitizers.
+        auto t1 = e5_sleeper(&g_e8Timer, 1h);
+        g_e8Promise = new QPromise<int>();
+        g_e8Promise->start();
+        auto t2 = e6_awaiter(&g_e8Future, g_e8Promise->future());
+        auto t3 = e7_fetch(&g_e8Reply, nam, silentUrl);
+        spin(100);  // reply becomes in-flight; this is the LAST event processing
+        check(!g_e8Reply.reply.isNull() && !g_e8Reply.reply->isFinished(), "shutdown-analog reply is in-flight");
+    }  // all three handles destroyed while suspended → three detached frames
+    check(!g_e8Timer.localDestroyed && !g_e8Future.localDestroyed && !g_e8Reply.localDestroyed,
+          "all three frames detached (locals alive), matching E5-E7");
+}
+
+static void e8_verifyAfterOwnersDestroyed(bool namDestroyedRepliesGone) {
+    check(!g_e8Timer.resumed && !g_e8Future.resumed && !g_e8Reply.resumed,
+          "nothing resumed during owner destruction: no event loop, queued delivery never happens");
+    check(namDestroyedRepliesGone, "QNAM parent backstop destroyed the in-flight reply at owner destruction");
+    finding("with no live event loop, detached frames are inert: destroying owners (QNAM included) resumes "
+            "nothing — but the frames and their locals are permanently leaked, and the reply cleanup falls "
+            "entirely to the QNAM parent backstop (the RAII wrapper never ran)");
+}
+
+// ---------------------------------------------------------------------------
+// E9: exception behavior — unawaited tasks swallow silently (R5-1's premise);
+// awaited tasks rethrow.
+// ---------------------------------------------------------------------------
+
+static QCoro::Task<> e9_throwerSync() {
+    throw std::runtime_error("boom-sync");
+    co_return;  // unreachable; makes this a coroutine
+}
+
+static QCoro::Task<> e9_throwerAsync() {
+    co_await QCoro::sleepFor(10ms);
+    throw std::runtime_error("boom-async");
+}
+
+static QCoro::Task<> e9_awaitThrower(bool* caught) {
+    try {
+        co_await e9_throwerSync();
+    } catch (const std::runtime_error&) {
+        *caught = true;
+    }
+}
+
+static void e9() {
+    section("E9: stored-exception behavior of unawaited tasks");
+    bool threwAtCall = false;
+    try {
+        auto t = e9_throwerSync();
+        check(t.isReady(), "task that threw before its first suspension is immediately ready");
+    } catch (...) {
+        threwAtCall = true;
+    }
+    check(!threwAtCall, "exception did not propagate out of the coroutine call");
+
+    {
+        auto t = e9_throwerAsync();
+        spin(100);
+        check(t.isReady(), "task that threw after resuming is ready");
+    }  // destroyed unawaited, exception stored inside
+    finding("an unawaited task's exception is stored in the promise and vanishes silently when the handle "
+            "dies — no terminate, no log, nothing observes it (confirms R5-1: root coroutines need catch-alls)");
+
+    bool caught = false;
+    auto t = e9_awaitThrower(&caught);
+    check(caught, "awaiting a task whose body threw rethrows the stored exception to the awaiter");
+}
+
+// ---------------------------------------------------------------------------
+// E10: destroying a completed task's handle from inside its own completion
+// cascade (the sweep question, R5-1) — self-destruction vs deferred sweep.
+// ---------------------------------------------------------------------------
+
+struct E10State {
+    std::optional<QCoro::Task<>> slot;
+    bool innerDone = false;
+    bool contRan = false;
+    bool afterReset = false;
+};
+
+static QCoro::Task<> e10_inner(E10State* s) {
+    co_await QCoro::sleepFor(20ms);
+    s->innerDone = true;
+}
+
+static QCoro::Task<> e10_watcher(E10State* s) {
+    co_await *s->slot;  // resumes synchronously inside inner's final_suspend
+    s->contRan = true;
+    s->slot.reset();  // destroy the completed task's handle from its own completion cascade
+    s->afterReset = true;
+}
+
+static void e10() {
+    section("E10: destroy a completed task's handle from inside its own completion cascade");
+    E10State s;
+    s.slot = e10_inner(&s);
+    auto w = e10_watcher(&s);
+    spin(200);
+    check(s.innerDone && s.contRan && s.afterReset, "continuation ran and reset the slot without crashing");
+    finding("destroying a completed task's handle from within its own completion cascade did not crash here "
+            "(final_suspend resumes awaiters before releasing its own ref) — but a deferred sweep remains the "
+            "defensive choice; verify under ASAN before relying on this");
+}
+
+// ---------------------------------------------------------------------------
+// E11: std::stop_callback runs synchronously on the requesting thread — the
+// premise that forces queued indirection (R4-2).
+// ---------------------------------------------------------------------------
+
+static void e11() {
+    section("E11: std::stop_callback synchrony");
+    std::atomic<bool> inside{false};
+    bool ranInside = false;
+    std::stop_source src;
+    std::stop_callback cb(src.get_token(), [&] { ranInside = inside.load(); });
+    inside = true;
+    src.request_stop();
+    inside = false;
+    check(ranInside, "stop_callback ran synchronously inside request_stop() — raw callbacks must never "
+                     "resume coroutines directly");
+}
+
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv) {
+    QCoreApplication app(argc, argv);
+    std::printf("QCoro v0.13.0 phase-0 spike (Qt %s)\n", qVersion());
+
+    // Silent HTTP server: accepts connections, never responds — keeps replies
+    // in-flight indefinitely.
+    QTcpServer server;
+    if (!server.listen(QHostAddress::LocalHost, 0)) {
+        std::printf("FATAL: could not listen on localhost\n");
+        return 1;
+    }
+    QObject::connect(&server, &QTcpServer::newConnection, &server, [&server] {
+        server.nextPendingConnection();  // parented to the server; never respond
+    });
+    const QUrl silentUrl(QStringLiteral("http://127.0.0.1:%1/").arg(server.serverPort()));
+
+    auto nam = std::make_unique<QNetworkAccessManager>();
+
+    e1();
+    e2();
+    e3();
+    e9();
+    e10();
+    e11();
+    e4();
+    e5();
+    e6();
+    e7(nam.get(), silentUrl);
+
+    // Shutdown analog last: after e8_setup, no more event processing happens.
+    e8_setup(nam.get(), silentUrl);
+    QPointer<QNetworkReply> e8Reply = g_e8Reply.reply;
+    nam.reset();  // QNAM destroyed with an in-flight reply, loop never spins again
+    e8_verifyAfterOwnersDestroyed(e8Reply.isNull());
+
+    section("end-of-run leak accounting");
+    check(!g_e6a.localDestroyed, "E6a frame (future never finished) is still leaked at exit, as predicted");
+    check(!g_e8Timer.localDestroyed && !g_e8Future.localDestroyed && !g_e8Reply.localDestroyed,
+          "E8 detached frames are still leaked at exit, as predicted");
+    std::printf("\n%d CHECK failure(s). Deliberate frame leaks at exit: 4 (E6a + 3x E8).\n", g_checkFailures);
+    return g_checkFailures;
+}

--- a/spikes/qcoro/main.cpp
+++ b/spikes/qcoro/main.cpp
@@ -574,6 +574,16 @@ static E6State g_e8Chain;
 static E7State g_e8Reply;
 static QPromise<int> *g_e8Promise = nullptr;
 static bool g_e8ParseRan = false;
+static QFuture<int> g_e8Child;
+
+// The worker's production await (D6): move the payload out through
+// qCoro(future).takeResult() — which runs as its own inner QCoro task frame.
+static QCoro::Task<> e8_chainAwaiter(E6State *s, QFuture<int> f)
+{
+    Sentinel guard(&s->localDestroyed);
+    co_await qCoro(f).takeResult();
+    s->resumed = true;
+}
 
 static void e8_setup(QNetworkAccessManager *nam, const QUrl &silentUrl)
 {
@@ -585,21 +595,23 @@ static void e8_setup(QNetworkAccessManager *nam, const QUrl &silentUrl)
         g_e8Promise = new QPromise<int>();
         g_e8Promise->start();
         auto t2 = e6_awaiter(&g_e8Future, g_e8Promise->future());
-        // The production topology (D7): the facade returns .then(parse)'s
-        // CHILD future and the worker awaits the child, not the parent.
-        QFuture<int> child = g_e8Promise->future().then([](int v) {
+        // The production topology (D7/D6): the facade returns .then(parse)'s
+        // CHILD future and the worker awaits the child via takeResult().
+        g_e8Child = g_e8Promise->future().then([](int v) {
             g_e8ParseRan = true;
             return v + 1;
         });
-        auto t3 = e6_awaiter(&g_e8Chain, child);
+        auto t3 = e8_chainAwaiter(&g_e8Chain, g_e8Child);
         auto t4 = e7_fetch(&g_e8Reply, nam, silentUrl);
         spin(100); // reply becomes in-flight; this is the LAST event processing
         check(!g_e8Reply.reply.isNull() && !g_e8Reply.reply->isFinished(),
               "shutdown-analog reply is in-flight");
-    } // all four handles destroyed while suspended → four detached frames
+    } // all four handles destroyed while suspended → four detached top-level
+    // task frames (the sleeper and chain awaiter each also carry a detached
+    // inner frame: QCoro::sleepFor's and qCoro().takeResult()'s)
     check(!g_e8Timer.localDestroyed && !g_e8Future.localDestroyed && !g_e8Chain.localDestroyed
               && !g_e8Reply.localDestroyed,
-          "all four frames detached (locals alive), matching E5-E7");
+          "all four top-level frames detached (locals alive), matching E5-E7");
 }
 
 static void e8_verifyAfterOwnersDestroyed(bool namDestroyedRepliesGone)
@@ -612,6 +624,9 @@ static void e8_verifyAfterOwnersDestroyed(bool namDestroyedRepliesGone)
     check(!g_e8ParseRan,
           "the parse continuation on the chained child future never ran — promise death broke the "
           "production .then topology without parsing or resuming its awaiter");
+    check(g_e8Child.isCanceled() && g_e8Child.isFinished(),
+          "the chained child future is canceled and finished after promise destruction — the chain "
+          "reached its terminal state synchronously, no event loop involved");
     check(namDestroyedRepliesGone, "QNAM parent destroyed the in-flight reply at owner destruction");
     finding("with no live event loop, detached frames are inert: promises die unfinished (their "
             "futures cancel, "
@@ -791,18 +806,24 @@ int main(int argc, char **argv)
     nam.reset(); // QNAM destroyed with an in-flight reply, loop never spins again
     e8_verifyAfterOwnersDestroyed(e8Reply.isNull());
 
+    // Release main's own copy of the child future before leak accounting so
+    // the only remaining retainers of its shared state are the detached
+    // frames themselves.
+    g_e8Child = QFuture<int>();
+
     section("end-of-run leak accounting");
     check(!g_e6a.localDestroyed,
           "E6a frame (future never finished) is still leaked at exit, as predicted");
     check(!g_e8Timer.localDestroyed && !g_e8Future.localDestroyed && !g_e8Chain.localDestroyed
               && !g_e8Reply.localDestroyed,
           "E8 detached frames are still leaked at exit, as predicted");
-    std::printf("\n%d CHECK failure(s). Deliberate detached-frame leaks at exit: 5 tasks "
-                "(E6a + 4x E8, plus inner awaitable frames and whatever only they retain — "
-                "future shared state included). The sentinel checks above are the authoritative "
-                "accounting; what `leaks` roots varies by run — the reply frame is a stable root, "
-                "timer frames surface as root cycles, and the future frames usually stay hidden "
-                "behind Qt thread-data (pending cancel call-outs).\n",
+    std::printf("\n%d CHECK failure(s). Deliberate detached-frame leaks at exit: seven coroutine "
+                "frame allocations — five top-level task frames (E6a + 4x E8) plus two inner task "
+                "frames (QCoro::sleepFor's, qCoro().takeResult()'s) — and whatever only they "
+                "retain, future shared state included. The sentinel checks above are the "
+                "authoritative accounting; what `leaks` roots varies by run — the reply frame is "
+                "a stable root, timer frames surface as root cycles, and the future frames "
+                "usually stay hidden behind Qt thread-data (pending cancel call-outs).\n",
                 g_checkFailures);
     return g_checkFailures;
 }

--- a/spikes/qcoro/main.cpp
+++ b/spikes/qcoro/main.cpp
@@ -8,10 +8,10 @@
 //
 // Exit code: number of failed CHECKs (0 = every experiment ran as designed).
 
-#include <QCoroTask>
 #include <QCoroFuture>
-#include <QCoroTimer>
 #include <QCoroNetworkReply>
+#include <QCoroTask>
+#include <QCoroTimer>
 
 #include <QCoreApplication>
 #include <QElapsedTimer>
@@ -29,6 +29,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdio>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -38,51 +39,97 @@ using namespace std::chrono_literals;
 
 static int g_checkFailures = 0;
 
-static void check(bool ok, const char* what) {
+static void check(bool ok, const char *what)
+{
     std::printf("  %s CHECK   %s\n", ok ? "[ok]" : "[!!]", what);
     if (!ok) {
         ++g_checkFailures;
     }
 }
 
-static void finding(const char* what) {
+static void finding(const char *what)
+{
     std::printf("  ==== FINDING %s\n", what);
 }
 
-static void section(const char* name) {
+static void section(const char *name)
+{
     std::printf("\n[%s]\n", name);
 }
 
 // Process events for roughly `ms` milliseconds.
-static void spin(int ms) {
+static void spin(int ms)
+{
     QEventLoop loop;
     QTimer::singleShot(ms, &loop, &QEventLoop::quit);
     loop.exec();
 }
 
+// Process events until `done` returns true, or fail after a generous timeout.
+// Condition-driven waiting keeps the experiments robust under load — fixed
+// spin windows were an intermittent-flake source.
+static bool spinUntil(const std::function<bool()> &done, int maxMs = 5000)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (!done() && timer.elapsed() < maxMs) {
+        spin(10);
+    }
+    return done();
+}
+
 // Frame-local RAII sentinel: proves whether a suspended frame's locals'
 // destructors ran (the R6-1 reply-release mechanism the spec leans on).
-struct Sentinel {
-    explicit Sentinel(bool* flag) : m_flag(flag) {}
-    Sentinel(const Sentinel&) = delete;
-    Sentinel& operator=(const Sentinel&) = delete;
+struct Sentinel
+{
+    explicit Sentinel(bool *flag)
+        : m_flag(flag)
+    {}
+    Sentinel(const Sentinel &) = delete;
+    Sentinel &operator=(const Sentinel &) = delete;
     ~Sentinel() { *m_flag = true; }
+
 private:
-    bool* m_flag;
+    bool *m_flag;
 };
 
 // Copy/move-counting payload for the result() vs takeResult() experiment.
-struct Counted {
+struct Counted
+{
     static inline int copies = 0;
     static inline int moves = 0;
-    static void reset() { copies = 0; moves = 0; }
+    static void reset()
+    {
+        copies = 0;
+        moves = 0;
+    }
     int v = 0;
     Counted() = default;
-    explicit Counted(int x) : v(x) {}
-    Counted(const Counted& o) : v(o.v) { ++copies; }
-    Counted(Counted&& o) noexcept : v(o.v) { ++moves; }
-    Counted& operator=(const Counted& o) { v = o.v; ++copies; return *this; }
-    Counted& operator=(Counted&& o) noexcept { v = o.v; ++moves; return *this; }
+    explicit Counted(int x)
+        : v(x)
+    {}
+    Counted(const Counted &o)
+        : v(o.v)
+    {
+        ++copies;
+    }
+    Counted(Counted &&o) noexcept
+        : v(o.v)
+    {
+        ++moves;
+    }
+    Counted &operator=(const Counted &o)
+    {
+        v = o.v;
+        ++copies;
+        return *this;
+    }
+    Counted &operator=(Counted &&o) noexcept
+    {
+        v = o.v;
+        ++moves;
+        return *this;
+    }
 };
 
 // ---------------------------------------------------------------------------
@@ -91,25 +138,30 @@ struct Counted {
 // run synchronously.)
 // ---------------------------------------------------------------------------
 
-struct E1State {
+struct E1State
+{
     bool resumed = false;
     int value = 0;
 };
 
-static QCoro::Task<> e1_awaitReady(E1State* s) {
+static QCoro::Task<> e1_awaitReady(E1State *s)
+{
     QFuture<int> f = QtFuture::makeReadyValueFuture(42);
     s->value = co_await f;
     s->resumed = true;
 }
 
-static void e1() {
+static void e1()
+{
     section("E1: co_await on an already-finished QFuture");
     E1State s;
     auto t = e1_awaitReady(&s);
-    check(s.resumed && s.value == 42, "coroutine ran to completion during the call, no event loop involved");
+    check(s.resumed && s.value == 42,
+          "coroutine ran to completion during the call, no event loop involved");
     check(t.isReady(), "task handle reports ready immediately");
     if (s.resumed) {
-        finding("awaiting a finished future never suspends: continuation runs synchronously inside the call");
+        finding("awaiting a finished future never suspends: continuation runs synchronously inside "
+                "the call");
     } else {
         finding("awaiting a finished future SUSPENDS (needs the event loop to resume)");
     }
@@ -119,7 +171,8 @@ static void e1() {
     auto f2 = f.then([&thenRan](int) { thenRan = true; });
     check(f2.isFinished(), "contextless .then chain on a finished future is itself finished");
     if (thenRan) {
-        finding("QFuture::then (no context) on a finished future runs the continuation synchronously");
+        finding(
+            "QFuture::then (no context) on a finished future runs the continuation synchronously");
     } else {
         finding("QFuture::then (no context) on a finished future did NOT run synchronously");
     }
@@ -132,19 +185,22 @@ static void e1() {
 // to bound re-entrancy if this is synchronous.)
 // ---------------------------------------------------------------------------
 
-struct E2State {
+struct E2State
+{
     std::atomic<bool> insideFinish{false};
     bool resumedInsideFinish = false;
     bool resumed = false;
 };
 
-static QCoro::Task<> e2_await(E2State* s, QFuture<int> f) {
+static QCoro::Task<> e2_await(E2State *s, QFuture<int> f)
+{
     co_await f;
     s->resumedInsideFinish = s->insideFinish.load();
     s->resumed = true;
 }
 
-static void e2() {
+static void e2()
+{
     section("E2: resumption when a QPromise finishes while a coroutine is suspended on its future");
     E2State s;
     QPromise<int> p;
@@ -156,12 +212,12 @@ static void e2() {
     p.finish();
     s.insideFinish = false;
     const bool resumedSynchronously = s.resumed;
-    spin(50);
-    check(s.resumed, "coroutine resumed once events were processed");
+    check(spinUntil([&] { return s.resumed; }), "coroutine resumed once events were processed");
     if (resumedSynchronously || s.resumedInsideFinish) {
         finding("QPromise::finish() resumed the awaiter SYNCHRONOUSLY on the finishing stack");
     } else {
-        finding("QPromise::finish() returned before the awaiter resumed — QCoro's QFuture awaiter delivers "
+        finding("QPromise::finish() returned before the awaiter resumed — QCoro's QFuture awaiter "
+                "delivers "
                 "resumption through the event loop (QFutureWatcher), i.e. queued");
     }
 }
@@ -170,24 +226,28 @@ static void e2() {
 // E3: result() vs takeResult() on the single-consumer path — copy/move counts.
 // ---------------------------------------------------------------------------
 
-struct E3State {
+struct E3State
+{
     int value = 0;
     bool done = false;
 };
 
-static QCoro::Task<> e3_direct(E3State* s, QFuture<Counted> f) {
+static QCoro::Task<> e3_direct(E3State *s, QFuture<Counted> f)
+{
     Counted c = co_await f;
     s->value = c.v;
     s->done = true;
 }
 
-static QCoro::Task<> e3_take(E3State* s, QFuture<Counted> f) {
+static QCoro::Task<> e3_take(E3State *s, QFuture<Counted> f)
+{
     Counted c = co_await qCoro(f).takeResult();
     s->value = c.v;
     s->done = true;
 }
 
-static QFuture<Counted> e3_makeReady(int v) {
+static QFuture<Counted> e3_makeReady(int v)
+{
     QPromise<Counted> p;
     p.start();
     p.addResult(Counted(v));
@@ -195,7 +255,8 @@ static QFuture<Counted> e3_makeReady(int v) {
     return p.future();
 }
 
-static void e3() {
+static void e3()
+{
     section("E3: result() vs takeResult() on the single-consumer path");
     {
         QFuture<Counted> f = e3_makeReady(5);
@@ -203,8 +264,11 @@ static void e3() {
         E3State s;
         auto t = e3_direct(&s, f);
         check(s.done && s.value == 5, "direct co_await returned the payload");
-        std::printf("       plain `co_await future`:            %d copies, %d moves\n", Counted::copies, Counted::moves);
-        check(Counted::copies >= 1, "plain co_await copies the payload out of the future (QFuture::result())");
+        std::printf("       plain `co_await future`:            %d copies, %d moves\n",
+                    Counted::copies,
+                    Counted::moves);
+        check(Counted::copies >= 1,
+              "plain co_await copies the payload out of the future (QFuture::result())");
     }
     {
         QFuture<Counted> f = e3_makeReady(6);
@@ -212,9 +276,12 @@ static void e3() {
         E3State s;
         auto t = e3_take(&s, f);
         check(s.done && s.value == 6, "takeResult co_await returned the payload");
-        std::printf("       `co_await qCoro(f).takeResult()`:   %d copies, %d moves\n", Counted::copies, Counted::moves);
+        std::printf("       `co_await qCoro(f).takeResult()`:   %d copies, %d moves\n",
+                    Counted::copies,
+                    Counted::moves);
         check(Counted::copies == 0, "takeResult path performs no copies (moves only)");
-        finding("qCoro(future).takeResult() is the move-out path for the worker's single-consumer payloads");
+        finding("qCoro(future).takeResult() is the move-out path for the worker's single-consumer "
+                "payloads");
     }
 }
 
@@ -223,10 +290,12 @@ static void e3() {
 // stop, resumption queued (request_stop() returns before the sleeper resumes).
 // ---------------------------------------------------------------------------
 
-struct SleepShared {
+struct SleepShared
+{
     QPromise<bool> p;
     std::atomic_flag fired = ATOMIC_FLAG_INIT;
-    void complete(bool stopped) {
+    void complete(bool stopped)
+    {
         if (!fired.test_and_set()) {
             p.addResult(stopped);
             p.finish();
@@ -235,9 +304,10 @@ struct SleepShared {
 };
 
 // Returns true if woken by stop, false if the full duration elapsed.
-static QCoro::Task<bool> stopSleep(std::chrono::milliseconds ms, std::stop_token tok, QObject* ctx) {
+static QCoro::Task<bool> stopSleep(std::chrono::milliseconds ms, std::stop_token tok, QObject *ctx)
+{
     if (tok.stop_requested()) {
-        co_return true;  // checkpoint: a pre-stopped wait never suspends
+        co_return true; // checkpoint: a pre-stopped wait never suspends
     }
     auto st = std::make_shared<SleepShared>();
     st->p.start();
@@ -252,7 +322,8 @@ static QCoro::Task<bool> stopSleep(std::chrono::milliseconds ms, std::stop_token
     co_return stopped;
 }
 
-struct E4State {
+struct E4State
+{
     std::atomic<bool> insideRequestStop{false};
     bool resumedInsideRequestStop = false;
     bool stopped = false;
@@ -260,7 +331,11 @@ struct E4State {
     qint64 elapsedMs = 0;
 };
 
-static QCoro::Task<> e4_run(E4State* s, std::chrono::milliseconds ms, std::stop_token tok, QObject* ctx) {
+static QCoro::Task<> e4_run(E4State *s,
+                            std::chrono::milliseconds ms,
+                            std::stop_token tok,
+                            QObject *ctx)
+{
     QElapsedTimer timer;
     timer.start();
     s->stopped = co_await stopSleep(ms, tok, ctx);
@@ -269,7 +344,8 @@ static QCoro::Task<> e4_run(E4State* s, std::chrono::milliseconds ms, std::stop_
     s->done = true;
 }
 
-static void e4() {
+static void e4()
+{
     section("E4: stop-interruptible sleep primitive (queued wake on stop)");
     QObject ctx;
 
@@ -284,12 +360,13 @@ static void e4() {
         src.request_stop();
         s.insideRequestStop = false;
         const bool resumedDuringRequestStop = s.done;
-        spin(100);
-        check(s.done && s.stopped, "sleeper woke promptly and reported 'stopped'");
+        check(spinUntil([&] { return s.done; }) && s.stopped,
+              "sleeper woke promptly and reported 'stopped'");
         check(!resumedDuringRequestStop && !s.resumedInsideRequestStop,
               "request_stop() returned before the sleeper resumed (queued wakeup, R4-2)");
         check(s.elapsedMs < 1000, "wake latency far below the 5s sleep duration");
-        std::printf("       stop wake latency: ~%lldms after request_stop()\n", static_cast<long long>(s.elapsedMs));
+        std::printf("       stop wake latency: ~%lldms after request_stop()\n",
+                    static_cast<long long>(s.elapsedMs));
     }
 
     // b) undisturbed sleep completes normally
@@ -297,8 +374,8 @@ static void e4() {
         std::stop_source src;
         E4State s;
         auto t = e4_run(&s, 50ms, src.get_token(), &ctx);
-        spin(200);
-        check(s.done && !s.stopped, "undisturbed 50ms sleep completed normally");
+        check(spinUntil([&] { return s.done; }) && !s.stopped,
+              "undisturbed 50ms sleep completed normally");
     }
 
     // c) pre-stopped token: never suspends
@@ -307,9 +384,11 @@ static void e4() {
         src.request_stop();
         E4State s;
         auto t = e4_run(&s, 5000ms, src.get_token(), &ctx);
-        check(s.done && s.stopped, "sleep with an already-stopped token completed synchronously (checkpoint)");
+        check(s.done && s.stopped,
+              "sleep with an already-stopped token completed synchronously (checkpoint)");
     }
-    finding("a stop-interruptible sleep built on QPromise + queued stop_callback delivers R4-2's contract");
+    finding("a stop-interruptible sleep built on QPromise + queued stop_callback delivers R4-2's "
+            "contract");
 }
 
 // ---------------------------------------------------------------------------
@@ -318,39 +397,48 @@ static void e4() {
 // (R5-2/R6-1).
 // ---------------------------------------------------------------------------
 
-struct E5State {
+struct E5State
+{
     bool localDestroyed = false;
     bool resumed = false;
 };
 
-static QCoro::Task<> e5_sleeper(E5State* s, std::chrono::milliseconds duration) {
+static QCoro::Task<> e5_sleeper(E5State *s, std::chrono::milliseconds duration)
+{
     Sentinel guard(&s->localDestroyed);
     co_await QCoro::sleepFor(duration);
     s->resumed = true;
 }
 
-static void e5() {
+static void e5()
+{
     section("E5: destroy Task handle while suspended on a timer");
     E5State s;
     {
         auto t = e5_sleeper(&s, 100ms);
         check(!t.isReady(), "sleeper is suspended");
-    }  // Task handle destroyed here, coroutine still suspended
+    } // Task handle destroyed here, coroutine still suspended
     const bool destroyedWithHandle = s.localDestroyed;
     if (destroyedWithHandle) {
-        finding("destroying the Task handle destroyed the suspended frame (locals' destructors ran)");
+        finding(
+            "destroying the Task handle destroyed the suspended frame (locals' destructors ran)");
     } else {
-        finding("destroying the Task handle mid-suspend DETACHES the coroutine: the frame survives and "
-                "frame locals' destructors do NOT run (falsifies R5-2/R6-1's mechanism)");
+        finding(
+            "destroying the Task handle mid-suspend DETACHES the coroutine: the frame survives and "
+            "frame locals' destructors do NOT run (falsifies R5-2/R6-1's mechanism)");
     }
-    spin(300);
+    spinUntil([&] { return s.localDestroyed; });
     if (s.resumed) {
-        finding("the detached coroutine RESUMED when its timer later fired — a destroyed handle does not "
+        finding("the detached coroutine RESUMED when its timer later fired — a destroyed handle "
+                "does not "
                 "prevent resumption while an event loop still runs");
     }
-    check(s.localDestroyed, "frame was destroyed by the end of the experiment (either with the handle, or at completion)");
+    check(s.localDestroyed,
+          "frame was destroyed by the end of the experiment (either with the handle, or at "
+          "completion)");
     if (!destroyedWithHandle && s.resumed && s.localDestroyed) {
-        finding("a detached coroutine that runs to completion self-destroys at final_suspend (refcount drops to 0)");
+        finding("a detached coroutine that runs to completion self-destroys at final_suspend "
+                "(refcount drops to 0)");
     }
 }
 
@@ -359,12 +447,14 @@ static void e5() {
 // (frame leak) checked at the end of main.
 // ---------------------------------------------------------------------------
 
-struct E6State {
+struct E6State
+{
     bool localDestroyed = false;
     bool resumed = false;
 };
 
-static QCoro::Task<> e6_awaiter(E6State* s, QFuture<int> f) {
+static QCoro::Task<> e6_awaiter(E6State *s, QFuture<int> f)
+{
     Sentinel guard(&s->localDestroyed);
     co_await f;
     s->resumed = true;
@@ -373,9 +463,10 @@ static QCoro::Task<> e6_awaiter(E6State* s, QFuture<int> f) {
 // E6a state is global: the never-finished frame is deliberately leaked and
 // re-checked at the end of main.
 static E6State g_e6a;
-static QPromise<int>* g_e6aPromise = nullptr;
+static QPromise<int> *g_e6aPromise = nullptr;
 
-static void e6() {
+static void e6()
+{
     section("E6: destroy Task handle while suspended on a QFuture");
 
     // a) promise never finishes, no live handle: what happens to the frame?
@@ -385,7 +476,8 @@ static void e6() {
         auto t = e6_awaiter(&g_e6a, g_e6aPromise->future());
     }
     if (!g_e6a.localDestroyed) {
-        finding("with the handle destroyed and the future never finishing, the suspended frame is LEAKED — "
+        finding("with the handle destroyed and the future never finishing, the suspended frame is "
+                "LEAKED — "
                 "QCoro 0.13 has no way to destroy a suspended detached coroutine from outside");
     } else {
         finding("frame was destroyed with the handle despite the pending future");
@@ -401,10 +493,11 @@ static void e6() {
     check(!s.localDestroyed, "frame detached (matches E5)");
     p.addResult(1);
     p.finish();
-    spin(50);
+    spinUntil([&] { return s.localDestroyed; });
     if (s.resumed) {
-        finding("finishing the future after the handle was destroyed RESUMED the detached coroutine "
-                "(QFutureWatcher lives in the frame, so it survives handle destruction)");
+        finding(
+            "finishing the future after the handle was destroyed RESUMED the detached coroutine "
+            "(QFutureWatcher lives in the frame, so it survives handle destruction)");
     }
     check(s.localDestroyed, "detached frame self-destroyed after completing");
 }
@@ -414,18 +507,21 @@ static void e6() {
 // dispatch-time RAII reply wrapper (D3).
 // ---------------------------------------------------------------------------
 
-struct E7State {
+struct E7State
+{
     bool localDestroyed = false;
     bool resumed = false;
     QPointer<QNetworkReply> reply;
 };
 
-static QCoro::Task<> e7_fetch(E7State* s, QNetworkAccessManager* nam, QUrl url) {
-    QNetworkReply* r = nam->get(QNetworkRequest(url));
+static QCoro::Task<> e7_fetch(E7State *s, QNetworkAccessManager *nam, QUrl url)
+{
+    QNetworkReply *r = nam->get(QNetworkRequest(url));
     s->reply = r;
     // D3's dispatch-time RAII wrapper, one level down: the frame owns the reply.
-    struct ReplyReleaser {
-        QNetworkReply* r;
+    struct ReplyReleaser
+    {
+        QNetworkReply *r;
         ~ReplyReleaser() { r->deleteLater(); }
     } releaser{r};
     Sentinel guard(&s->localDestroyed);
@@ -433,27 +529,36 @@ static QCoro::Task<> e7_fetch(E7State* s, QNetworkAccessManager* nam, QUrl url) 
     s->resumed = true;
 }
 
-static void e7(QNetworkAccessManager* nam, const QUrl& silentUrl) {
+static void e7(QNetworkAccessManager *nam, const QUrl &silentUrl)
+{
     section("E7: destroy Task handle while suspended on an in-flight QNetworkReply");
     E7State s;
     {
         auto t = e7_fetch(&s, nam, silentUrl);
-        spin(100);  // let the request reach the silent server: genuinely in-flight
-        check(!t.isReady() && !s.reply.isNull() && !s.reply->isFinished(), "reply is in-flight, coroutine suspended");
+        spin(100); // let the request reach the silent server: genuinely in-flight
+        check(!t.isReady() && !s.reply.isNull() && !s.reply->isFinished(),
+              "reply is in-flight, coroutine suspended");
     }
-    check(!s.localDestroyed, "frame detached, so the RAII reply wrapper did NOT run at handle destruction");
-    check(!s.reply.isNull(), "reply still alive (owned by the detached frame's wrapper + QNAM parent)");
-    s.reply->abort();  // force a finished emission after the handle is gone
+    check(!s.localDestroyed,
+          "frame detached, so the RAII reply wrapper did NOT run at handle destruction");
+    check(!s.reply.isNull(),
+          "reply still alive (owned by the detached frame's wrapper + QNAM parent)");
+    s.reply->abort(); // force a finished emission after the handle is gone
     const bool resumedDuringAbort = s.resumed;
-    spin(50);
-    check(!resumedDuringAbort, "abort()'s finished emission did not resume the coroutine synchronously (queued connection)");
+    spinUntil([&] { return s.localDestroyed; });
+    check(!resumedDuringAbort,
+          "abort()'s finished emission did not resume the coroutine synchronously (queued "
+          "connection)");
     if (s.resumed) {
-        finding("a finished emission after handle destruction RESUMED the detached coroutine via its still-live "
-                "queued connection — handle destruction does NOT sever the reply-awaiter connection");
+        finding(
+            "a finished emission after handle destruction RESUMED the detached coroutine via its "
+            "still-live "
+            "queued connection — handle destruction does NOT sever the reply-awaiter connection");
     }
-    check(s.localDestroyed, "detached frame self-destroyed after completing; RAII wrapper released the reply");
-    spin(50);  // let deleteLater run
-    check(s.reply.isNull(), "reply deleted via the wrapper's deleteLater once the loop spun");
+    check(s.localDestroyed,
+          "detached frame self-destroyed after completing; RAII wrapper released the reply");
+    check(spinUntil([&] { return s.reply.isNull(); }),
+          "reply deleted via the wrapper's deleteLater once the loop spun");
 }
 
 // ---------------------------------------------------------------------------
@@ -466,9 +571,10 @@ static void e7(QNetworkAccessManager* nam, const QUrl& silentUrl) {
 static E5State g_e8Timer;
 static E6State g_e8Future;
 static E7State g_e8Reply;
-static QPromise<int>* g_e8Promise = nullptr;
+static QPromise<int> *g_e8Promise = nullptr;
 
-static void e8_setup(QNetworkAccessManager* nam, const QUrl& silentUrl) {
+static void e8_setup(QNetworkAccessManager *nam, const QUrl &silentUrl)
+{
     section("E8: post-exec shutdown analog (no further event processing after this point)");
     {
         // Duration far beyond the setup spin below — the timer must still be
@@ -478,20 +584,38 @@ static void e8_setup(QNetworkAccessManager* nam, const QUrl& silentUrl) {
         g_e8Promise->start();
         auto t2 = e6_awaiter(&g_e8Future, g_e8Promise->future());
         auto t3 = e7_fetch(&g_e8Reply, nam, silentUrl);
-        spin(100);  // reply becomes in-flight; this is the LAST event processing
-        check(!g_e8Reply.reply.isNull() && !g_e8Reply.reply->isFinished(), "shutdown-analog reply is in-flight");
-    }  // all three handles destroyed while suspended → three detached frames
+        spin(100); // reply becomes in-flight; this is the LAST event processing
+        check(!g_e8Reply.reply.isNull() && !g_e8Reply.reply->isFinished(),
+              "shutdown-analog reply is in-flight");
+    } // all three handles destroyed while suspended → three detached frames
     check(!g_e8Timer.localDestroyed && !g_e8Future.localDestroyed && !g_e8Reply.localDestroyed,
           "all three frames detached (locals alive), matching E5-E7");
 }
 
-static void e8_verifyAfterOwnersDestroyed(bool namDestroyedRepliesGone) {
+static void e8_verifyAfterOwnersDestroyed(bool namDestroyedRepliesGone, bool brokenThenRan)
+{
     check(!g_e8Timer.resumed && !g_e8Future.resumed && !g_e8Reply.resumed,
           "nothing resumed during owner destruction: no event loop, queued delivery never happens");
-    check(namDestroyedRepliesGone, "QNAM parent backstop destroyed the in-flight reply at owner destruction");
-    finding("with no live event loop, detached frames are inert: destroying owners (QNAM included) resumes "
-            "nothing — but the frames and their locals are permanently leaked, and the reply cleanup falls "
-            "entirely to the QNAM parent backstop (the RAII wrapper never ran)");
+    check(!g_e8Future.localDestroyed && !g_e6a.localDestroyed,
+          "destroying the unfinished promises canceled their futures without resuming the detached "
+          "awaiters");
+    check(
+        !brokenThenRan,
+        ".then continuations on the broken promises' futures did not run (Qt canceled the chain)");
+    check(namDestroyedRepliesGone, "QNAM parent destroyed the in-flight reply at owner destruction");
+    finding("with no live event loop, detached frames are inert: promises die unfinished (their "
+            "futures cancel, "
+            ".then chains do not run, awaiters stay suspended), destroying owners (QNAM included) "
+            "resumes "
+            "nothing — but the frames and their locals are permanently leaked, and the reply "
+            "cleanup falls "
+            "entirely to the QNAM parent (the RAII wrapper never ran)");
+    finding("mid-session the same promise destruction would be ER1's hazard — the watcher would "
+            "deliver a "
+            "canceled-future resumption into result() once the loop spun — which is why D2 "
+            "requires every "
+            "live promise to reach a final state and confines unfinished-promise death to "
+            "post-loop shutdown");
 }
 
 // ---------------------------------------------------------------------------
@@ -499,25 +623,29 @@ static void e8_verifyAfterOwnersDestroyed(bool namDestroyedRepliesGone) {
 // awaited tasks rethrow.
 // ---------------------------------------------------------------------------
 
-static QCoro::Task<> e9_throwerSync() {
+static QCoro::Task<> e9_throwerSync()
+{
     throw std::runtime_error("boom-sync");
-    co_return;  // unreachable; makes this a coroutine
+    co_return; // unreachable; makes this a coroutine
 }
 
-static QCoro::Task<> e9_throwerAsync() {
+static QCoro::Task<> e9_throwerAsync()
+{
     co_await QCoro::sleepFor(10ms);
     throw std::runtime_error("boom-async");
 }
 
-static QCoro::Task<> e9_awaitThrower(bool* caught) {
+static QCoro::Task<> e9_awaitThrower(bool *caught)
+{
     try {
         co_await e9_throwerSync();
-    } catch (const std::runtime_error&) {
+    } catch (const std::runtime_error &) {
         *caught = true;
     }
 }
 
-static void e9() {
+static void e9()
+{
     section("E9: stored-exception behavior of unawaited tasks");
     bool threwAtCall = false;
     try {
@@ -530,11 +658,12 @@ static void e9() {
 
     {
         auto t = e9_throwerAsync();
-        spin(100);
-        check(t.isReady(), "task that threw after resuming is ready");
-    }  // destroyed unawaited, exception stored inside
-    finding("an unawaited task's exception is stored in the promise and vanishes silently when the handle "
-            "dies — no terminate, no log, nothing observes it (confirms R5-1: root coroutines need catch-alls)");
+        check(spinUntil([&] { return t.isReady(); }), "task that threw after resuming is ready");
+    } // destroyed unawaited, exception stored inside
+    finding("an unawaited task's exception is stored in the promise and vanishes silently when the "
+            "handle "
+            "dies — no terminate, no log, nothing observes it (confirms R5-1: root coroutines need "
+            "catch-alls)");
 
     bool caught = false;
     auto t = e9_awaitThrower(&caught);
@@ -546,34 +675,41 @@ static void e9() {
 // cascade (the sweep question, R5-1) — self-destruction vs deferred sweep.
 // ---------------------------------------------------------------------------
 
-struct E10State {
+struct E10State
+{
     std::optional<QCoro::Task<>> slot;
     bool innerDone = false;
     bool contRan = false;
     bool afterReset = false;
 };
 
-static QCoro::Task<> e10_inner(E10State* s) {
+static QCoro::Task<> e10_inner(E10State *s)
+{
     co_await QCoro::sleepFor(20ms);
     s->innerDone = true;
 }
 
-static QCoro::Task<> e10_watcher(E10State* s) {
-    co_await *s->slot;  // resumes synchronously inside inner's final_suspend
+static QCoro::Task<> e10_watcher(E10State *s)
+{
+    co_await *s->slot; // resumes synchronously inside inner's final_suspend
     s->contRan = true;
-    s->slot.reset();  // destroy the completed task's handle from its own completion cascade
+    s->slot.reset(); // destroy the completed task's handle from its own completion cascade
     s->afterReset = true;
 }
 
-static void e10() {
+static void e10()
+{
     section("E10: destroy a completed task's handle from inside its own completion cascade");
     E10State s;
     s.slot = e10_inner(&s);
     auto w = e10_watcher(&s);
-    spin(200);
-    check(s.innerDone && s.contRan && s.afterReset, "continuation ran and reset the slot without crashing");
-    finding("destroying a completed task's handle from within its own completion cascade did not crash here "
-            "(final_suspend resumes awaiters before releasing its own ref) — but a deferred sweep remains the "
+    spinUntil([&] { return s.afterReset; });
+    check(s.innerDone && s.contRan && s.afterReset,
+          "continuation ran and reset the slot without crashing");
+    finding("destroying a completed task's handle from within its own completion cascade did not "
+            "crash here "
+            "(final_suspend resumes awaiters before releasing its own ref) — but a deferred sweep "
+            "remains the "
             "defensive choice; verify under ASAN before relying on this");
 }
 
@@ -582,7 +718,8 @@ static void e10() {
 // premise that forces queued indirection (R4-2).
 // ---------------------------------------------------------------------------
 
-static void e11() {
+static void e11()
+{
     section("E11: std::stop_callback synchrony");
     std::atomic<bool> inside{false};
     bool ranInside = false;
@@ -591,13 +728,15 @@ static void e11() {
     inside = true;
     src.request_stop();
     inside = false;
-    check(ranInside, "stop_callback ran synchronously inside request_stop() — raw callbacks must never "
-                     "resume coroutines directly");
+    check(ranInside,
+          "stop_callback ran synchronously inside request_stop() — raw callbacks must never "
+          "resume coroutines directly");
 }
 
 // ---------------------------------------------------------------------------
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv)
+{
     QCoreApplication app(argc, argv);
     std::printf("QCoro v0.13.0 phase-0 spike (Qt %s)\n", qVersion());
 
@@ -609,7 +748,7 @@ int main(int argc, char** argv) {
         return 1;
     }
     QObject::connect(&server, &QTcpServer::newConnection, &server, [&server] {
-        server.nextPendingConnection();  // parented to the server; never respond
+        server.nextPendingConnection(); // parented to the server; never respond
     });
     const QUrl silentUrl(QStringLiteral("http://127.0.0.1:%1/").arg(server.serverPort()));
 
@@ -629,13 +768,33 @@ int main(int argc, char** argv) {
     // Shutdown analog last: after e8_setup, no more event processing happens.
     e8_setup(nam.get(), silentUrl);
     QPointer<QNetworkReply> e8Reply = g_e8Reply.reply;
-    nam.reset();  // QNAM destroyed with an in-flight reply, loop never spins again
-    e8_verifyAfterOwnersDestroyed(e8Reply.isNull());
+
+    // Real shutdown destroys queued entries' unfinished QPromises (the hub's
+    // deques die with it). Pin that here: attach continuations, then destroy
+    // the promises unfinished — futures cancel, chains break, detached
+    // awaiters must not resume. Nulling the globals also makes the leaked
+    // frames unreachable, so `leaks --atExit` can see them as roots.
+    bool brokenThenRan = false;
+    g_e8Promise->future().then([&brokenThenRan](int) { brokenThenRan = true; });
+    g_e6aPromise->future().then([&brokenThenRan](int) { brokenThenRan = true; });
+    delete g_e8Promise;
+    g_e8Promise = nullptr;
+    delete g_e6aPromise;
+    g_e6aPromise = nullptr;
+
+    nam.reset(); // QNAM destroyed with an in-flight reply, loop never spins again
+    e8_verifyAfterOwnersDestroyed(e8Reply.isNull(), brokenThenRan);
 
     section("end-of-run leak accounting");
-    check(!g_e6a.localDestroyed, "E6a frame (future never finished) is still leaked at exit, as predicted");
+    check(!g_e6a.localDestroyed,
+          "E6a frame (future never finished) is still leaked at exit, as predicted");
     check(!g_e8Timer.localDestroyed && !g_e8Future.localDestroyed && !g_e8Reply.localDestroyed,
           "E8 detached frames are still leaked at exit, as predicted");
-    std::printf("\n%d CHECK failure(s). Deliberate frame leaks at exit: 4 (E6a + 3x E8).\n", g_checkFailures);
+    std::printf("\n%d CHECK failure(s). Deliberate detached-frame leaks at exit: 4 tasks "
+                "(E6a + 3x E8, plus inner awaitable frames). The sentinel checks above are the "
+                "authoritative accounting; `leaks` reports the reply frame as a root, while the "
+                "timer/future frames stay reachable from Qt thread-data (pending cancel "
+                "call-outs, timer registrations).\n",
+                g_checkFailures);
     return g_checkFailures;
 }

--- a/spikes/qcoro/main.cpp
+++ b/spikes/qcoro/main.cpp
@@ -570,8 +570,10 @@ static void e7(QNetworkAccessManager *nam, const QUrl &silentUrl)
 
 static E5State g_e8Timer;
 static E6State g_e8Future;
+static E6State g_e8Chain;
 static E7State g_e8Reply;
 static QPromise<int> *g_e8Promise = nullptr;
+static bool g_e8ParseRan = false;
 
 static void e8_setup(QNetworkAccessManager *nam, const QUrl &silentUrl)
 {
@@ -583,25 +585,33 @@ static void e8_setup(QNetworkAccessManager *nam, const QUrl &silentUrl)
         g_e8Promise = new QPromise<int>();
         g_e8Promise->start();
         auto t2 = e6_awaiter(&g_e8Future, g_e8Promise->future());
-        auto t3 = e7_fetch(&g_e8Reply, nam, silentUrl);
+        // The production topology (D7): the facade returns .then(parse)'s
+        // CHILD future and the worker awaits the child, not the parent.
+        QFuture<int> child = g_e8Promise->future().then([](int v) {
+            g_e8ParseRan = true;
+            return v + 1;
+        });
+        auto t3 = e6_awaiter(&g_e8Chain, child);
+        auto t4 = e7_fetch(&g_e8Reply, nam, silentUrl);
         spin(100); // reply becomes in-flight; this is the LAST event processing
         check(!g_e8Reply.reply.isNull() && !g_e8Reply.reply->isFinished(),
               "shutdown-analog reply is in-flight");
-    } // all three handles destroyed while suspended → three detached frames
-    check(!g_e8Timer.localDestroyed && !g_e8Future.localDestroyed && !g_e8Reply.localDestroyed,
-          "all three frames detached (locals alive), matching E5-E7");
+    } // all four handles destroyed while suspended → four detached frames
+    check(!g_e8Timer.localDestroyed && !g_e8Future.localDestroyed && !g_e8Chain.localDestroyed
+              && !g_e8Reply.localDestroyed,
+          "all four frames detached (locals alive), matching E5-E7");
 }
 
-static void e8_verifyAfterOwnersDestroyed(bool namDestroyedRepliesGone, bool brokenThenRan)
+static void e8_verifyAfterOwnersDestroyed(bool namDestroyedRepliesGone)
 {
-    check(!g_e8Timer.resumed && !g_e8Future.resumed && !g_e8Reply.resumed,
+    check(!g_e8Timer.resumed && !g_e8Future.resumed && !g_e8Chain.resumed && !g_e8Reply.resumed,
           "nothing resumed during owner destruction: no event loop, queued delivery never happens");
-    check(!g_e8Future.localDestroyed && !g_e6a.localDestroyed,
+    check(!g_e8Future.localDestroyed && !g_e8Chain.localDestroyed && !g_e6a.localDestroyed,
           "destroying the unfinished promises canceled their futures without resuming the detached "
           "awaiters");
-    check(
-        !brokenThenRan,
-        ".then continuations on the broken promises' futures did not run (Qt canceled the chain)");
+    check(!g_e8ParseRan,
+          "the parse continuation on the chained child future never ran — promise death broke the "
+          "production .then topology without parsing or resuming its awaiter");
     check(namDestroyedRepliesGone, "QNAM parent destroyed the in-flight reply at owner destruction");
     finding("with no live event loop, detached frames are inert: promises die unfinished (their "
             "futures cancel, "
@@ -770,31 +780,29 @@ int main(int argc, char **argv)
     QPointer<QNetworkReply> e8Reply = g_e8Reply.reply;
 
     // Real shutdown destroys queued entries' unfinished QPromises (the hub's
-    // deques die with it). Pin that here: attach continuations, then destroy
-    // the promises unfinished — futures cancel, chains break, detached
-    // awaiters must not resume. Nulling the globals also makes the leaked
-    // frames unreachable, so `leaks --atExit` can see them as roots.
-    bool brokenThenRan = false;
-    g_e8Promise->future().then([&brokenThenRan](int) { brokenThenRan = true; });
-    g_e6aPromise->future().then([&brokenThenRan](int) { brokenThenRan = true; });
+    // deques die with it). Destroy them here — the parent future, its
+    // .then(parse) chain, and the child future the chain awaiter suspends on
+    // must all cancel without parsing or resuming anything.
     delete g_e8Promise;
     g_e8Promise = nullptr;
     delete g_e6aPromise;
     g_e6aPromise = nullptr;
 
     nam.reset(); // QNAM destroyed with an in-flight reply, loop never spins again
-    e8_verifyAfterOwnersDestroyed(e8Reply.isNull(), brokenThenRan);
+    e8_verifyAfterOwnersDestroyed(e8Reply.isNull());
 
     section("end-of-run leak accounting");
     check(!g_e6a.localDestroyed,
           "E6a frame (future never finished) is still leaked at exit, as predicted");
-    check(!g_e8Timer.localDestroyed && !g_e8Future.localDestroyed && !g_e8Reply.localDestroyed,
+    check(!g_e8Timer.localDestroyed && !g_e8Future.localDestroyed && !g_e8Chain.localDestroyed
+              && !g_e8Reply.localDestroyed,
           "E8 detached frames are still leaked at exit, as predicted");
-    std::printf("\n%d CHECK failure(s). Deliberate detached-frame leaks at exit: 4 tasks "
-                "(E6a + 3x E8, plus inner awaitable frames). The sentinel checks above are the "
-                "authoritative accounting; `leaks` reports the reply frame as a root, while the "
-                "timer/future frames stay reachable from Qt thread-data (pending cancel "
-                "call-outs, timer registrations).\n",
+    std::printf("\n%d CHECK failure(s). Deliberate detached-frame leaks at exit: 5 tasks "
+                "(E6a + 4x E8, plus inner awaitable frames and whatever only they retain — "
+                "future shared state included). The sentinel checks above are the authoritative "
+                "accounting; what `leaks` roots varies by run — the reply frame is a stable root, "
+                "timer frames surface as root cycles, and the future frames usually stay hidden "
+                "behind Qt thread-data (pending cancel call-outs).\n",
                 g_checkFailures);
     return g_checkFailures;
 }


### PR DESCRIPTION
## Summary

Executes phasing step 0 of the frozen network-redesign spec: a standalone throwaway spike (`spikes/qcoro/`, QCoro pinned at v0.13.0, Qt 6.11.1) that exercises the spec's full question list and tries to falsify it. It succeeded once, which is exactly what the freeze invited.

**Headline (S1-1, falsifies R5-2's mechanism):** QCoro 0.13 task handles are refcounted shared references — destroying one while the coroutine is suspended *detaches* the frame. Locals' destructors do not run, the frame resumes normally if its awaited event is later delivered, and nothing can destroy a suspended coroutine from outside.

**The shutdown conclusion survives by a different route (S1-2/S1-3):** every awaiter resumes only through the event loop (reply = queued connection to a frame-owned context, future = `QFutureWatcher` event delivery, timer = timer events), so post-`exec()` destruction resumes nothing. Costs made explicit: detached frames leak a bounded few hundred bytes at process exit, and the QNAM parent is the *only* shutdown reply cleanup — the dispatch-time RAII wrapper is a live-session mechanism.

Everything else held: queued stop wakeups + a working stop-interruptible sleep prototype (S1-5), synchronous ready-future continuation (S1-6), `takeResult()` as the 0-copy move-out path (S1-7), silent unawaited-task exceptions (S1-8), synchronous task completion cascades vs queued QFuture boundaries (S1-9), FetchContent hygiene flags (S1-10).

## Review rounds folded in

Three same-day follow-up rounds (Tom + external review) are folded into the spec, review history, and spike:

- stale destroy-while-suspended clauses rewritten (D3 reply ownership, two testing-plan pins)
- E8 destroys the unfinished `QPromise`s the way the hub's deques die, with the production chained-future topology: parent → `.then(parse)` → child, awaited via `co_await qCoro(f).takeResult()`; the child is asserted canceled+finished *synchronously* after promise death
- the integration leak pin is bounded to the transitive closure of detached frames (a no-shared-state criterion is impossible: QCoro's awaiter stores a `QFuture` in the frame)
- FetchContent reference corrected: QCoro's own flags only — forcing global `BUILD_TESTING` off would have disabled acquisition's whole test suite (the spike now proves `ctest` stays intact with zero QCoro tests)
- leak accounting: in-process sentinels are authoritative; `leaks` output varies by run and is a cross-check on its rooted subset

## Docs

- `docs/design/network-redesign.md` → revision 8 (status, D2, D3, D6, shutdown, dependency, phasing step 0)
- `docs/design/network-redesign-reviews.md` → round S1 + three follow-ups + revision log
- `spikes/qcoro/` → CMake project, experiments, README; build trees gitignored

## Test plan

- [x] 42 spike checks pass; 16+ consecutive clean runs (plain + ASAN), including concurrent-load runs
- [x] `clang-format --dry-run --Werror` clean on the spike source
- [x] fresh-configure verification: parent `BUILD_TESTING=ON`, `ctest -N` lists zero QCoro tests, no examples built
- [x] macOS `leaks` cross-check consistent with the documented detached-frame accounting
- [x] no production source touched — the acquisition build and test suite are unaffected

Still open from phasing step 0: the 2,000-tab batch measurement (same spike target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)