### PR TITLE
Phase-0 batch-scale measurement (S2): 2,000-tab population and abort cost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Phase-0 spike build trees (spikes/qcoro/README.md).
 /build-spike/
 /build-spike-asan/
+/build-spike-release/
 
 # Acquisitions installers are currently built here.
 /deploy/

--- a/docs/design/network-redesign-reviews.md
+++ b/docs/design/network-redesign-reviews.md
@@ -399,7 +399,14 @@ deque entry with realistic `QNetworkRequest` + endpoint label +
 timestamp + `QPromise` + stop token; facade `.then(parse)` chain
 with no parent-future retention; eager per-fetch worker suspended on
 `co_await qCoro(child).takeResult()` with the post-await stop check;
-handles in a worker-owned container; one `stop_source`), then aborts
+handles in a worker-owned container; one `stop_source`). The
+parsed-outcome stand-in is sized to the real facade payload —
+`sizeof(std::expected<poe::StashWrapper, FetchError>)` is 336 bytes
+against the actual headers (static_asserted in the spike;
+`poe::CharacterWrapper`'s outcome is 744, so a character-scale run
+costs ~0.8 KB more per entry) — because the outcome occupies
+compile-time frame slots per entry, not just completed shared state
+(see the follow-up below). It then aborts
 the maximal standing population — every entry still queued:
 `request_stop()` → drain loop completes each entry `Canceled` at the
 dequeue checkpoint → queued watcher resumptions → deferred sweep.
@@ -407,15 +414,16 @@ Numbers from a Release build, Qt 6.11.1/macOS, allocator bytes via
 `malloc_zone_statistics`, footprint via `task_vm_info`; validity
 checks also pass under ASAN.
 
-- **S2-1 (standing population ≈ 5.8 KB/entry, linear):** the full
+- **S2-1 (standing population ≈ 6.5 KB/entry, linear):** the full
   per-entry machinery — queue entry (request with auth/UA headers
   and transfer timeout, label, timestamp, promise, token), parse
   chain and child future, suspended worker frame plus its inner
-  `takeResult` task frame and `QFutureWatcher`, owned handle —
-  costs ~5.8 KB of heap. Measured 5838/5810/5812 bytes per entry at
+  `takeResult` task frame and `QFutureWatcher`, owned handle, with
+  the outcome slots sized to the real stash wrapper — costs
+  ~6.5 KB of heap. Measured 6542/6516/6520 bytes per entry at
   N=200/2,000/10,000 — linear, no superlinear surprise. The 2,000-tab
-  population is **~11.1 MB heap (~10–11 MB footprint)**; even
-  10,000 tabs is ~55 MB.
+  population is **~12.4 MB heap (~11–13 MB footprint)**; even
+  10,000 tabs is ~62 MB.
 - **S2-2 (abort cost is milliseconds):** at N=2,000 the whole abort
   runs ~2–4 ms: Canceled-completion burst ~2.4 ms (2,000 promise
   completions with the pass-through parse continuations running
@@ -434,8 +442,8 @@ checks also pass under ASAN.
   retention, no frame residue (ER5/D2's no-retention rule holds at
   the population level). Intermediate points: after the Canceled
   burst the child shared states hold 2,000 stored outcomes
-  (+4.8 MB over baseline); after resumption only the completed
-  frames remain (+1.9 MB); the sweep releases those.
+  (+6.6 MB over baseline); after resumption only the completed
+  frames remain (+2.3 MB); the sweep releases those.
 - **S2-4 (scale does not bend the S1 contracts):** at 2,000 entries
   no worker resumed during submission (all suspended), none resumed
   on the completing stack (queued delivery holds under a 2,000-
@@ -451,6 +459,27 @@ already routes any stutter to UI-side coalescing), real dispatch and
 replies (at most the gate cap of 2 in flight — negligible against
 the queued population), and success-path payload memory (an
 items-pipeline sizing concern, not machinery cost).
+
+**S2 follow-up (external review, same day).** Two corrections. (1)
+The first cut's 104-byte synthetic outcome **undercounted the
+standing population**: the real stash outcome is 336 bytes
+(character: 744), and `sizeof` of the outcome type is baked into
+the population at compile time — it landed in three frame slots per
+entry along the `takeResult` path (the worker frame's local, the
+inner task's promise result storage, and the awaiter's move-out
+path), not just in completed shared state. The stand-in is now
+padded to the real stash wrapper and static_asserted against
+drift; per-entry cost rose 5.8 → ~6.5 KB (measured +706 bytes,
+consistent with three 232-byte slot growths) and every number above
+was re-measured. The verdict is unchanged. (2) The resumption-wait
+**timeout path was itself an S1-1 hazard**: after a 30 s timeout the
+code went on to sweep the handles and destroy the update — detaching
+any still-suspended worker frames while they retain pointers into
+the update's counters, which a later scale's event processing could
+resume into freed state. On timeout the binary now deliberately
+leaks the update (mirroring the shutdown contract: detached frames
+must outlive nothing that can still be delivered to them) and runs
+no further scales.
 
 ## Revision log
 
@@ -611,10 +640,16 @@ items-pipeline sizing concern, not machinery cost).
   in D3.
 - **July 19, 2026 (batch-scale measurement, round S2 — freeze
   holds)** — phasing step 0 completed: the 2,000-tab measurement ran
-  (`spikes/qcoro/batch.cpp`). Standing population ~5.8 KB/entry,
-  linear to 10,000 (~11 MB at 2,000 tabs); abort costs milliseconds
+  (`spikes/qcoro/batch.cpp`). Standing population ~6.5 KB/entry,
+  linear to 10,000 (~12.4 MB at 2,000 tabs); abort costs milliseconds
   end to end (~2–4 ms at 2,000; the ~22 ms per-pump sleep wake
   dominates) and memory unwinds to baseline with zero leaks after
   the sweep. Verdict: no flow control, no incremental reclamation —
   the spec's "measure first" clauses resolved with numbers; D6 and
-  the phasing sketch cite S2 inline.
+  the phasing sketch cite S2 inline. Same-day follow-up (external
+  review): the outcome stand-in resized from 104 bytes to the real
+  336-byte stash wrapper (it occupies three compile-time frame slots
+  per entry — the first cut undercounted by ~0.7 KB/entry; numbers
+  re-measured, verdict unchanged), and the resumption-wait timeout
+  path fixed to leak the update deliberately instead of sweeping
+  live frames into a use-after-free.

--- a/docs/design/network-redesign-reviews.md
+++ b/docs/design/network-redesign-reviews.md
@@ -387,8 +387,70 @@ coroutine frame allocations leak — five top-level task frames (E6a +
 four E8) plus the two inner task frames (`QCoro::sleepFor`'s,
 `qCoro().takeResult()`'s).
 
-The 2,000-tab batch measurement — the other half of phasing step 0 —
-remains open.
+## Phase-0 batch-scale measurement (round S2) — July 19, 2026
+
+The other half of phasing step 0: peak memory and abort cost for the
+full promise/future/frame/token population at the 2,000-tab scale
+the items-pipeline doc names. Second binary in the spike project
+(`spikes/qcoro/batch.cpp`, target `qcoro_batch`) — a fresh process
+for clean memory baselines, away from `qcoro_spike`'s deliberate
+leaks. It builds the spec's production topology per entry (pump
+deque entry with realistic `QNetworkRequest` + endpoint label +
+timestamp + `QPromise` + stop token; facade `.then(parse)` chain
+with no parent-future retention; eager per-fetch worker suspended on
+`co_await qCoro(child).takeResult()` with the post-await stop check;
+handles in a worker-owned container; one `stop_source`), then aborts
+the maximal standing population — every entry still queued:
+`request_stop()` → drain loop completes each entry `Canceled` at the
+dequeue checkpoint → queued watcher resumptions → deferred sweep.
+Numbers from a Release build, Qt 6.11.1/macOS, allocator bytes via
+`malloc_zone_statistics`, footprint via `task_vm_info`; validity
+checks also pass under ASAN.
+
+- **S2-1 (standing population ≈ 5.8 KB/entry, linear):** the full
+  per-entry machinery — queue entry (request with auth/UA headers
+  and transfer timeout, label, timestamp, promise, token), parse
+  chain and child future, suspended worker frame plus its inner
+  `takeResult` task frame and `QFutureWatcher`, owned handle —
+  costs ~5.8 KB of heap. Measured 5838/5810/5812 bytes per entry at
+  N=200/2,000/10,000 — linear, no superlinear surprise. The 2,000-tab
+  population is **~11.1 MB heap (~10–11 MB footprint)**; even
+  10,000 tabs is ~55 MB.
+- **S2-2 (abort cost is milliseconds):** at N=2,000 the whole abort
+  runs ~2–4 ms: Canceled-completion burst ~2.4 ms (2,000 promise
+  completions with the pass-through parse continuations running
+  inline on the completing stack), resumption drain ~1.1 ms (2,000
+  queued `QFutureWatcher` resumptions through the event loop),
+  handle sweep ~0.3 ms. N=10,000 stays ~13 ms. The dominant abort
+  latency is therefore the one-time ~22 ms stop-interruptible
+  pacing-sleep wake per pump (S1-5), not anything that scales with
+  population. The batch-submit burst itself (build + chain + launch
+  to first suspension, synchronous on the main thread) is ~8 ms at
+  N=2,000.
+- **S2-3 (memory fully unwinds; no retention at scale):** heap
+  returns to ~baseline after the sweep (+0.23 MB at N=2,000,
+  allocator noise) and `leaks --atExit` reports **zero leaks** —
+  the canceled population leaves nothing behind: no completed-future
+  retention, no frame residue (ER5/D2's no-retention rule holds at
+  the population level). Intermediate points: after the Canceled
+  burst the child shared states hold 2,000 stored outcomes
+  (+4.8 MB over baseline); after resumption only the completed
+  frames remain (+1.9 MB); the sweep releases those.
+- **S2-4 (scale does not bend the S1 contracts):** at 2,000 entries
+  no worker resumed during submission (all suspended), none resumed
+  on the completing stack (queued delivery holds under a 2,000-
+  completion burst), every post-await stop check fired, no parse
+  continuation did real work on the abort path, and every handle was
+  ready before the sweep.
+
+**Verdict:** the numbers do not demand flow control — bounded
+flow control stays unbuilt (the spec's "measure first" is resolved),
+and D6's deferred sweep needs no incremental per-completion
+reclamation. Not simulated: `QueueUpdated` signal emissions (D6
+already routes any stutter to UI-side coalescing), real dispatch and
+replies (at most the gate cap of 2 in flight — negligible against
+the queued population), and success-path payload memory (an
+items-pipeline sizing concern, not machinery cost).
 
 ## Revision log
 
@@ -547,3 +609,12 @@ remains open.
   leak-tool description to its actual output, and separated
   body-completion local unwinding from frame-allocation reclamation
   in D3.
+- **July 19, 2026 (batch-scale measurement, round S2 — freeze
+  holds)** — phasing step 0 completed: the 2,000-tab measurement ran
+  (`spikes/qcoro/batch.cpp`). Standing population ~5.8 KB/entry,
+  linear to 10,000 (~11 MB at 2,000 tabs); abort costs milliseconds
+  end to end (~2–4 ms at 2,000; the ~22 ms per-pump sleep wake
+  dominates) and memory unwinds to baseline with zero leaks after
+  the sweep. Verdict: no flow control, no incremental reclamation —
+  the spec's "measure first" clauses resolved with numbers; D6 and
+  the phasing sketch cite S2 inline.

--- a/docs/design/network-redesign-reviews.md
+++ b/docs/design/network-redesign-reviews.md
@@ -402,7 +402,8 @@ with no parent-future retention; eager per-fetch worker suspended on
 handles in a worker-owned container; one `stop_source`). The
 parsed-outcome stand-in is sized to the real facade payload —
 `sizeof(std::expected<poe::StashWrapper, FetchError>)` is 336 bytes
-against the actual headers (static_asserted in the spike;
+against the actual headers (the spike static_asserts the probed
+numbers, not the production types — re-probe manually if they change;
 `poe::CharacterWrapper`'s outcome is 744, so a character-scale run
 costs ~0.8 KB more per entry) — because the outcome occupies
 compile-time frame slots per entry, not just completed shared state

--- a/docs/design/network-redesign.md
+++ b/docs/design/network-redesign.md
@@ -1,7 +1,8 @@
 # Network Redesign: Typed Facade, Coroutine Pumps, and the Gate
 
 **Status: ACCEPTED July 19, 2026 (revision 8) — frozen for
-implementation; phase-0 spike executed.** Drafted July 18 and
+implementation; phase 0 complete (spike + batch-scale
+measurement).** Drafted July 18 and
 reviewed through six rounds in two days, plus one post-freeze errata
 batch (rev 7: eight corrections and contract completions, all
 shrinking — R7 in the review history). The review process converged
@@ -14,8 +15,11 @@ Rev 8 is the first such evidence round: the phase-0 QCoro spike
 destroy-while-suspended mechanism — QCoro task handles detach, not
 destroy — and the shutdown section now rests on
 detach-plus-no-delivery (S1-1..S1-4); every other spike-tested
-premise held (S1-5..S1-10). The finding tables (ER, IR, R4-\*,
-R5-\*, R6-\*, R7, S1), the round narratives, the reversal records,
+premise held (S1-5..S1-10). The batch-scale measurement (round S2,
+same spike project) closed phasing step 0's open question with
+numbers: ~5.8 KB per entry, milliseconds to abort 2,000 tabs — no
+flow control (S2-1..S2-4). The finding tables (ER, IR, R4-\*,
+R5-\*, R6-\*, R7, S1, S2), the round narratives, the reversal records,
 and the revision log live in `network-redesign-reviews.md`; this
 spec records only current decisions and cites finding IDs inline
 where a decision's shape came from a review. No production code has
@@ -612,8 +616,11 @@ forum and login traffic as-is, documented here.
   held in owned members (a handle container for the per-fetch tasks)
   — no fire-and-forget anywhere. A task handle owns a coroutine
   frame, not a payload, so this does not conflict with D2's
-  no-future-retention rule; but 2,000 frames are memory, which is
-  exactly what the phase-0 measurement weighs. Ownership is for
+  no-future-retention rule; 2,000 frames are memory, which the
+  phase-0 measurement weighed: ~5.8 KB per entry for the whole
+  standing machinery (entry + promise + chain + suspended frames +
+  watcher + handle), ~11 MB at the 2,000-tab scale, linear to
+  10,000 (S2-1) — acceptable. Ownership is for
   **lifetime control only** — it supervises nothing (R5-1, exception
   policy). Handles are reclaimed by a **deferred sweep that runs
   outside any completing coroutine** (R5-1): finalization triggered
@@ -625,8 +632,10 @@ forum and login traffic as-is, documented here.
   destroys **completed** tasks only — destroying a suspended task's
   handle would detach it, not stop it (S1-1/S1-4), and the frame
   would still resume later while the loop runs. No
-  incremental per-completion reclamation beyond that sweep until the
-  measurement demands it. "Update done" remains completion counting:
+  incremental per-completion reclamation beyond that sweep — the
+  measurement did not demand it: sweeping 2,000 completed frames
+  takes ~0.3 ms and releases everything (heap back to baseline,
+  zero leaks — S2-2, S2-3). "Update done" remains completion counting:
   each per-fetch coroutine increments its counter after its await
   resolves (post-await check first), and the completion that
   reconciles the counters triggers finalization, exactly as today's
@@ -1168,11 +1177,15 @@ sleep.)
    hygiene flags. Headline result: R5-2's mechanism was falsified
    (handle destruction detaches, S1-1) and the shutdown contract now
    rests on detach-plus-no-delivery (S1-2); everything else held.
-   **Still open from this step, one measurement:** batch submission
-   at the 2,000-tab scale the items-pipeline doc names — peak memory
-   and abort cost for the full promise/future/frame/token
-   population. Measure first; bounded flow control is speculative
-   machinery until numbers demand it.
+   **The step's one open measurement — batch submission at the
+   2,000-tab scale the items-pipeline doc names — executed July 19,
+   2026** (round S2, `spikes/qcoro/batch.cpp` in the same spike
+   project): the full promise/future/frame/token population costs
+   ~5.8 KB per entry (~11 MB at 2,000 tabs, linear to 10,000), a
+   full abort drains in ~2–4 ms with the per-pump ~22 ms sleep wake
+   dominating, and memory unwinds to baseline with zero leaks after
+   the sweep (S2-1..S2-4). The numbers did not demand flow control,
+   so none is designed; step 0 is closed.
 1. Manager test harness against current code (no behavior change).
 2. QCoro dependency + primitives (stop-interruptible sleep, gate)
    with their tests.

--- a/docs/design/network-redesign.md
+++ b/docs/design/network-redesign.md
@@ -17,7 +17,7 @@ destroy — and the shutdown section now rests on
 detach-plus-no-delivery (S1-1..S1-4); every other spike-tested
 premise held (S1-5..S1-10). The batch-scale measurement (round S2,
 same spike project) closed phasing step 0's open question with
-numbers: ~5.8 KB per entry, milliseconds to abort 2,000 tabs — no
+numbers: ~6.5 KB per entry, milliseconds to abort 2,000 tabs — no
 flow control (S2-1..S2-4). The finding tables (ER, IR, R4-\*,
 R5-\*, R6-\*, R7, S1, S2), the round narratives, the reversal records,
 and the revision log live in `network-redesign-reviews.md`; this
@@ -617,9 +617,10 @@ forum and login traffic as-is, documented here.
   — no fire-and-forget anywhere. A task handle owns a coroutine
   frame, not a payload, so this does not conflict with D2's
   no-future-retention rule; 2,000 frames are memory, which the
-  phase-0 measurement weighed: ~5.8 KB per entry for the whole
+  phase-0 measurement weighed: ~6.5 KB per entry for the whole
   standing machinery (entry + promise + chain + suspended frames +
-  watcher + handle), ~11 MB at the 2,000-tab scale, linear to
+  watcher + handle, outcome slots sized to the real stash wrapper),
+  ~12.4 MB at the 2,000-tab scale, linear to
   10,000 (S2-1) — acceptable. Ownership is for
   **lifetime control only** — it supervises nothing (R5-1, exception
   policy). Handles are reclaimed by a **deferred sweep that runs
@@ -1181,7 +1182,7 @@ sleep.)
    2,000-tab scale the items-pipeline doc names — executed July 19,
    2026** (round S2, `spikes/qcoro/batch.cpp` in the same spike
    project): the full promise/future/frame/token population costs
-   ~5.8 KB per entry (~11 MB at 2,000 tabs, linear to 10,000), a
+   ~6.5 KB per entry (~12.4 MB at 2,000 tabs, linear to 10,000), a
    full abort drains in ~2–4 ms with the per-pump ~22 ms sleep wake
    dominating, and memory unwinds to baseline with zero leaks after
    the sweep (S2-1..S2-4). The numbers did not demand flow control,

--- a/spikes/qcoro/CMakeLists.txt
+++ b/spikes/qcoro/CMakeLists.txt
@@ -56,8 +56,20 @@ target_link_libraries(qcoro_spike PRIVATE
     QCoro6::Network
 )
 
+# Batch-scale measurement (phasing step 0's open measurement): peak memory and
+# abort cost at the 2,000-tab scale. Separate binary so it gets a fresh
+# process — clean memory baselines, away from qcoro_spike's deliberate leaks.
+add_executable(qcoro_batch batch.cpp)
+target_link_libraries(qcoro_batch PRIVATE
+    Qt6::Core
+    Qt6::Network
+    QCoro6::Core
+)
+
 option(SPIKE_ASAN "Build the spike with AddressSanitizer" OFF)
 if(SPIKE_ASAN)
-    target_compile_options(qcoro_spike PRIVATE -fsanitize=address -fno-omit-frame-pointer)
-    target_link_options(qcoro_spike PRIVATE -fsanitize=address)
+    foreach(tgt qcoro_spike qcoro_batch)
+        target_compile_options(${tgt} PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+        target_link_options(${tgt} PRIVATE -fsanitize=address)
+    endforeach()
 endif()

--- a/spikes/qcoro/README.md
+++ b/spikes/qcoro/README.md
@@ -2,8 +2,9 @@
 
 Running-code evidence for the network-redesign spec's phasing step 0
 (`docs/design/network-redesign.md`). Findings are recorded as review
-round **S1** in `docs/design/network-redesign-reviews.md`; the spec's
-D2/D6/shutdown/dependency sections cite them inline.
+rounds **S1** (semantics, `main.cpp`) and **S2** (batch-scale
+measurement, `batch.cpp`) in `docs/design/network-redesign-reviews.md`;
+the spec's D2/D6/shutdown/dependency sections cite them inline.
 
 Standalone throwaway project — not part of the acquisition build.
 
@@ -13,13 +14,38 @@ cmake --build build-spike
 ./build-spike/qcoro_spike            # exit code = number of failed CHECKs
 ```
 
+## Batch-scale measurement (`qcoro_batch`)
+
+Second binary, same project: peak memory and abort cost for the full
+promise/future/frame/token population at the 2,000-tab scale (S2). It
+is a separate executable so it gets a fresh process — clean memory
+baselines, away from `qcoro_spike`'s deliberate leaks. Build it
+Release for quotable numbers:
+
+```sh
+cmake -S spikes/qcoro -B build-spike-release -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH=$HOME/Qt/6.11.1/macos
+cmake --build build-spike-release --target qcoro_batch
+./build-spike-release/qcoro_batch            # default scales: 200 (warm-up), 2000
+./build-spike-release/qcoro_batch 2000 10000 # explicit scales
+```
+
+Headline numbers (Release, Qt 6.11.1/macOS): ~5.8 KB heap per entry,
+linear through 10,000 (≈11 MB standing population at 2,000 tabs);
+full-abort cost ~2–4 ms at 2,000 (Canceled burst + queued
+resumptions + sweep — the ~22 ms per-pump sleep wake from S1-5
+dominates); heap returns to baseline afterward and `leaks --atExit`
+reports zero leaks.
+
 Optional verification passes:
 
 ```sh
 cmake -S spikes/qcoro -B build-spike-asan -DSPIKE_ASAN=ON \
       -DCMAKE_PREFIX_PATH=$HOME/Qt/6.11.1/macos
 cmake --build build-spike-asan && ./build-spike-asan/qcoro_spike
+./build-spike-asan/qcoro_batch                # S2 validity checks under ASAN
 leaks --atExit -- ./build-spike/qcoro_spike   # macOS leak accounting
+leaks --atExit -- ./build-spike-release/qcoro_batch  # expects ZERO leaks
 ```
 
 The binary prints CHECK lines (internal validity of each experiment)

--- a/spikes/qcoro/README.md
+++ b/spikes/qcoro/README.md
@@ -30,8 +30,10 @@ cmake --build build-spike-release --target qcoro_batch
 ./build-spike-release/qcoro_batch 2000 10000 # explicit scales
 ```
 
-Headline numbers (Release, Qt 6.11.1/macOS): ~5.8 KB heap per entry,
-linear through 10,000 (≈11 MB standing population at 2,000 tabs);
+Headline numbers (Release, Qt 6.11.1/macOS): ~6.5 KB heap per entry
+with outcome slots sized to the real stash wrapper (336 bytes;
+static_asserted), linear through 10,000 (≈12.4 MB standing
+population at 2,000 tabs);
 full-abort cost ~2–4 ms at 2,000 (Canceled burst + queued
 resumptions + sweep — the ~22 ms per-pump sleep wake from S1-5
 dominates); heap returns to baseline afterward and `leaks --atExit`

--- a/spikes/qcoro/README.md
+++ b/spikes/qcoro/README.md
@@ -31,9 +31,10 @@ cmake --build build-spike-release --target qcoro_batch
 ```
 
 Headline numbers (Release, Qt 6.11.1/macOS): ~6.5 KB heap per entry
-with outcome slots sized to the real stash wrapper (336 bytes;
-static_asserted), linear through 10,000 (≈12.4 MB standing
-population at 2,000 tabs);
+with outcome slots sized to the real stash wrapper (336 bytes,
+pinned by static_asserts to a July 19, 2026 size probe — re-verify
+manually if the production types change), linear through 10,000
+(≈12.4 MB standing population at 2,000 tabs);
 full-abort cost ~2–4 ms at 2,000 (Canceled burst + queued
 resumptions + sweep — the ~22 ms per-pump sleep wake from S1-5
 dominates); heap returns to baseline afterward and `leaks --atExit`

--- a/spikes/qcoro/batch.cpp
+++ b/spikes/qcoro/batch.cpp
@@ -1,0 +1,356 @@
+// Phase-0 batch-scale measurement (network-redesign spec, phasing step 0,
+// "still open from this step").
+//
+// Question: batch submission at the 2,000-tab scale the items-pipeline doc
+// names — peak memory and abort cost for the full promise/future/frame/token
+// population. Measure first; bounded flow control is speculative machinery
+// until numbers demand it.
+//
+// The program builds the spec's production topology per entry (D1/D2/D6/D7):
+//
+//   - a pump queue entry in a std::deque: QNetworkRequest (realistic URL,
+//     auth + UA headers, 10s transfer timeout), endpoint label, submission
+//     timestamp, the QPromise, and the update's stop_token;
+//   - the facade chain: `parent.future().then(parse)` returning the CHILD
+//     future; no parent future is retained after chaining (D2);
+//   - one eager per-fetch worker coroutine per entry, suspended on
+//     `co_await qCoro(child).takeResult()` (D6/S1-7), post-await stop check
+//     first (IR2), handle stored in a worker-owned container (R4-3);
+//   - one std::stop_source per update; every entry carries its token (D2).
+//
+// Scenario measured: the maximal standing population — every entry still
+// queued (none dispatched; mid-update at most the gate cap of 2 is ever
+// in-flight, negligible) — then a full abort:
+//
+//   request_stop() → drain loop pops each entry, sees the stopped token at
+//   the dequeue checkpoint, completes it Canceled (the synchronous burst,
+//   which also runs the facade's pass-through parse continuations on the
+//   completing stack) → the event loop delivers the queued QFutureWatcher
+//   resumptions (workers resume, see stop, return silently) → the deferred
+//   sweep destroys the completed handles (D6).
+//
+// Not measured here: the stop-interruptible pacing-sleep wakeup that starts
+// a real abort (~22ms, one per policy pump — S1-5), and payload memory
+// (canceled entries never carry payloads; success-path payloads are an
+// items-pipeline concern, not machinery cost).
+//
+// CHECK lines are internal validity (exit code = failures); the numbers are
+// the deliverable. Build with -DCMAKE_BUILD_TYPE=Release for quotable
+// numbers; the tool prints its build flavor.
+
+#include <QCoroFuture>
+#include <QCoroTask>
+
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QFuture>
+#include <QNetworkRequest>
+#include <QPromise>
+#include <QTimer>
+#include <QUrl>
+
+#include <cstdio>
+#include <cstdlib>
+#include <deque>
+#include <expected>
+#include <memory>
+#include <stop_token>
+#include <vector>
+
+#ifdef __APPLE__
+#include <mach/mach.h>
+#include <malloc/malloc.h>
+#endif
+
+static int g_checkFailures = 0;
+
+static void check(bool ok, const char *what)
+{
+    std::printf("  %s CHECK   %s\n", ok ? "[ok]" : "[!!]", what);
+    if (!ok) {
+        ++g_checkFailures;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Memory instrumentation (macOS): allocator bytes in use across all malloc
+// zones (the precise machinery cost) and the task's physical footprint (what
+// the OS actually charges the process).
+// ---------------------------------------------------------------------------
+
+struct MemSnapshot
+{
+    long long heapInUse = 0;
+    long long footprint = 0;
+};
+
+static MemSnapshot memNow()
+{
+    MemSnapshot m;
+#ifdef __APPLE__
+    malloc_statistics_t stats{};
+    malloc_zone_statistics(nullptr, &stats);
+    m.heapInUse = static_cast<long long>(stats.size_in_use);
+    task_vm_info_data_t vm{};
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    if (task_info(mach_task_self(), TASK_VM_INFO, reinterpret_cast<task_info_t>(&vm), &count)
+        == KERN_SUCCESS) {
+        m.footprint = static_cast<long long>(vm.phys_footprint);
+    }
+#endif
+    return m;
+}
+
+static double asMB(long long bytes)
+{
+    return static_cast<double>(bytes) / (1024.0 * 1024.0);
+}
+
+// ---------------------------------------------------------------------------
+// The spec's boundary types, shaped like D1/D7 (representative, not exact).
+// ---------------------------------------------------------------------------
+
+enum class ErrorKind { Network, Http, Parse, Protocol, RateLimited, Internal, Canceled };
+
+struct FetchError
+{
+    ErrorKind kind = ErrorKind::Internal;
+    int status = 0;
+    int attempts = 0;
+};
+
+using RawOutcome = std::expected<QByteArray, FetchError>;
+
+struct ParsedTab
+{
+    QString id;
+    QString name;
+    QString type;
+    std::vector<int> items;
+};
+
+using ParsedOutcome = std::expected<ParsedTab, FetchError>;
+
+// A pump queue entry (D1): request, endpoint label, capture timestamp,
+// promise, and the update's stop token.
+struct Entry
+{
+    QNetworkRequest request;
+    QString endpoint;
+    QDateTime submitted;
+    QPromise<RawOutcome> promise;
+    std::stop_token token;
+};
+
+struct BatchStats
+{
+    int expected = 0;
+    int finished = 0;     // coroutines that ran to co_return (measurement bookkeeping)
+    int canceled = 0;     // outcomes observed as Canceled
+    int staleResumes = 0; // post-await stop check fired (abort: all of them)
+    int parsesRan = 0;    // parse continuations that did real work (abort: none)
+};
+
+struct Update
+{
+    std::stop_source stop;
+    std::deque<Entry> queue;            // the pump's deque (D3)
+    std::vector<QCoro::Task<>> handles; // worker-owned handle container (R4-3)
+    BatchStats stats;
+};
+
+// The per-fetch worker coroutine (D6): one await site, post-await stop check
+// before touching anything, then completion counting.
+static QCoro::Task<> fetchOne(BatchStats *s, QFuture<ParsedOutcome> child, std::stop_token tok)
+{
+    ParsedOutcome r = co_await qCoro(child).takeResult();
+    if (tok.stop_requested()) { // post-await identity invariant (IR2)
+        ++s->staleResumes;
+        if (!r.has_value() && r.error().kind == ErrorKind::Canceled) {
+            ++s->canceled;
+        }
+        ++s->finished; // return silently (D2) — counters only
+        co_return;
+    }
+    ++s->finished;
+}
+
+// Batch submission (D6): build every entry, chain the facade parse, launch
+// the eager worker coroutine (it runs to its co_await and suspends), keep
+// only the child future inside the frame and the handle in the container.
+static void submitBatch(Update &u, int n)
+{
+    u.stats.expected = n;
+    u.handles.reserve(n);
+    const QByteArray bearer = QByteArrayLiteral("Bearer ") + QByteArray(60, 'x');
+    for (int i = 0; i < n; ++i) {
+        Entry &e = u.queue.emplace_back();
+        const QString tabId = QString::asprintf("%010llx",
+                                                static_cast<unsigned long long>(i) * 2654435761ull);
+        e.request = QNetworkRequest(
+            QUrl(QStringLiteral("https://api.pathofexile.com/stash/Standard/") + tabId));
+        e.request.setRawHeader("Authorization", bearer);
+        e.request.setRawHeader("User-Agent", "acquisition/spike (batch-scale measurement)");
+        e.request.setTransferTimeout(10'000); // the facade's invariant (R5-3)
+        e.endpoint = QStringLiteral("getStash");
+        e.submitted = QDateTime::currentDateTimeUtc();
+        e.token = u.stop.get_token();
+        e.promise.start();
+        // The facade (D7): chain parsing, return the child, retain no parent.
+        QFuture<ParsedOutcome> child = e.promise.future().then(
+            [s = &u.stats](RawOutcome r) -> ParsedOutcome {
+                if (!r.has_value()) {
+                    return std::unexpected(r.error()); // pass-through, no parse
+                }
+                ++s->parsesRan;
+                ParsedTab tab;
+                tab.id = QString::fromUtf8(r->left(10));
+                tab.name = QStringLiteral("Stash");
+                tab.type = QStringLiteral("PremiumStash");
+                return tab;
+            });
+        u.handles.push_back(fetchOne(&u.stats, std::move(child), e.token));
+    }
+}
+
+// The drain's abort path (D3): pop each entry, the dequeue checkpoint sees
+// the stopped token, complete Canceled. The facade's pass-through
+// continuation runs synchronously on this stack as each promise finishes.
+static void drainCanceled(Update &u)
+{
+    while (!u.queue.empty()) {
+        Entry e = std::move(u.queue.front());
+        u.queue.pop_front();
+        e.promise.addResult(std::unexpected(FetchError{ErrorKind::Canceled}));
+        e.promise.finish();
+    } // entry (and its promise) dies here — the child's shared state holds the outcome
+}
+
+// ---------------------------------------------------------------------------
+
+static void measureScale(int n, bool warmup)
+{
+    std::printf("\n[batch-scale measurement, N=%d%s]\n", n, warmup ? " (warm-up)" : "");
+
+    const MemSnapshot base = memNow();
+    QElapsedTimer t;
+
+    // --- batch submit: the full standing population comes into existence ---
+    t.start();
+    auto u = std::make_unique<Update>();
+    submitBatch(*u, n);
+    const double submitMs = t.nsecsElapsed() / 1e6;
+    const MemSnapshot pop = memNow();
+
+    check(u->stats.finished == 0, "no worker resumed during submission (all suspended)");
+    check(static_cast<int>(u->handles.size()) == n, "one owned handle per entry");
+
+    // --- abort: request_stop + the drain's synchronous Canceled burst ---
+    t.restart();
+    u->stop.request_stop();
+    drainCanceled(*u);
+    const double drainMs = t.nsecsElapsed() / 1e6;
+    const bool resumedDuringDrain = u->stats.finished != 0;
+    const MemSnapshot afterDrain = memNow();
+
+    check(!resumedDuringDrain,
+          "no worker resumed on the completing stack (QFutureWatcher delivery is queued)");
+
+    // --- the event loop delivers the queued resumptions ---
+    t.restart();
+    QElapsedTimer guard;
+    guard.start();
+    while (u->stats.finished < n && guard.elapsed() < 30'000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents, 100);
+    }
+    const double resumeMs = t.nsecsElapsed() / 1e6;
+    const MemSnapshot afterResume = memNow();
+
+    check(u->stats.finished == n, "every worker coroutine resumed and finished");
+    check(u->stats.canceled == n, "every worker observed a Canceled outcome");
+    check(u->stats.staleResumes == n, "every post-await stop check fired (IR2)");
+    check(u->stats.parsesRan == 0, "no parse continuation did real work on the abort path");
+
+    bool allReady = true;
+    for (const auto &h : u->handles) {
+        allReady = allReady && h.isReady();
+    }
+    check(allReady, "every handle reports ready before the sweep (sweep destroys completed only)");
+
+    // --- deferred sweep (D6): destroy the completed handles ---
+    t.restart();
+    u->handles.clear();
+    const double sweepMs = t.nsecsElapsed() / 1e6;
+    const MemSnapshot afterSweep = memNow();
+
+    u.reset(); // remaining update state (empty deque, stop_source, counters)
+    const MemSnapshot afterTeardown = memNow();
+
+    const double perEntry = static_cast<double>(pop.heapInUse - base.heapInUse) / n;
+    std::printf("       population:  heap +%.2f MB (%.0f bytes/entry), footprint +%.2f MB\n",
+                asMB(pop.heapInUse - base.heapInUse),
+                perEntry,
+                asMB(pop.footprint - base.footprint));
+    std::printf("       submit burst:            %8.2f ms  (build + chain + launch, synchronous)\n",
+                submitMs);
+    std::printf("       abort: Canceled burst:   %8.2f ms  (drain completes %d promises, "
+                "continuations inline)\n",
+                drainMs,
+                n);
+    std::printf("       abort: resumption drain: %8.2f ms  (%d queued watcher resumptions)\n",
+                resumeMs,
+                n);
+    std::printf("       abort: handle sweep:     %8.2f ms  (%d completed frames destroyed)\n",
+                sweepMs,
+                n);
+    std::printf("       abort total:             %8.2f ms  (+ one ~22ms pacing-sleep wake per "
+                "pump, S1-5)\n",
+                drainMs + resumeMs + sweepMs);
+    std::printf("       heap deltas vs baseline: after drain %+.2f MB, after resume %+.2f MB, "
+                "after sweep %+.2f MB, after teardown %+.2f MB\n",
+                asMB(afterDrain.heapInUse - base.heapInUse),
+                asMB(afterResume.heapInUse - base.heapInUse),
+                asMB(afterSweep.heapInUse - base.heapInUse),
+                asMB(afterTeardown.heapInUse - base.heapInUse));
+    std::printf("       footprint vs baseline:   after teardown %+.2f MB\n",
+                asMB(afterTeardown.footprint - base.footprint));
+}
+
+int main(int argc, char **argv)
+{
+    QCoreApplication app(argc, argv);
+#ifdef NDEBUG
+    const char *flavor = "release (NDEBUG)";
+#else
+    const char *flavor = "debug/unoptimized — configure with -DCMAKE_BUILD_TYPE=Release for "
+                         "quotable numbers";
+#endif
+    std::printf("QCoro v0.13.0 batch-scale measurement (Qt %s) — build flavor: %s\n",
+                qVersion(),
+                flavor);
+#ifndef __APPLE__
+    std::printf("NOTE: memory instrumentation is macOS-only; sizes will read 0 here\n");
+#endif
+
+    // Default: one small warm-up (pages in allocator and code paths, and gives
+    // a second point for scaling linearity), then the 2,000-tab scale.
+    std::vector<int> scales;
+    for (int i = 1; i < argc; ++i) {
+        const int n = std::atoi(argv[i]);
+        if (n > 0) {
+            scales.push_back(n);
+        }
+    }
+    if (scales.empty()) {
+        scales = {200, 2000};
+    }
+
+    for (size_t i = 0; i < scales.size(); ++i) {
+        measureScale(scales[i], scales.size() > 1 && i == 0);
+    }
+
+    std::printf("\n%d CHECK failure(s)\n", g_checkFailures);
+    return g_checkFailures;
+}

--- a/spikes/qcoro/batch.cpp
+++ b/spikes/qcoro/batch.cpp
@@ -125,12 +125,16 @@ struct FetchError
 using RawOutcome = std::expected<QByteArray, FetchError>;
 
 // Sized to the real facade payload: sizeof(std::expected<poe::StashWrapper,
-// FetchError>) is 336 bytes against the actual headers (measured July 19,
-// 2026; poe::CharacterWrapper's outcome is 744 — a character-scale run costs
-// ~0.8 KB more per entry). The size matters because the outcome occupies two
-// compile-time frame slots per entry — fetchOne's local and the inner
-// takeResult task's promise — plus, transiently, the child future's shared
-// state; an undersized stand-in undercounts every one of them.
+// FetchError>) probed at 336 bytes against the actual headers on July 19,
+// 2026 (poe::CharacterWrapper's outcome: 744 — a character-scale run costs
+// ~0.8 KB more per entry). The size matters because the outcome occupies
+// three compile-time frame slots per entry along the takeResult path —
+// fetchOne's local, the inner task's promise result storage, and the
+// awaiter's move-out path (the measured +706 B/entry over the 104-byte
+// first cut matches three slots) — plus, transiently, the child future's
+// shared state. The static_asserts below pin the stand-in to that probe's
+// NUMBERS, not to the production types: if poe::StashWrapper changes,
+// nothing here fires — re-run the size probe and re-pad by hand.
 struct ParsedTab
 {
     QString id;

--- a/spikes/qcoro/batch.cpp
+++ b/spikes/qcoro/batch.cpp
@@ -51,6 +51,7 @@
 #include <QTimer>
 #include <QUrl>
 
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <deque>
@@ -123,15 +124,26 @@ struct FetchError
 
 using RawOutcome = std::expected<QByteArray, FetchError>;
 
+// Sized to the real facade payload: sizeof(std::expected<poe::StashWrapper,
+// FetchError>) is 336 bytes against the actual headers (measured July 19,
+// 2026; poe::CharacterWrapper's outcome is 744 — a character-scale run costs
+// ~0.8 KB more per entry). The size matters because the outcome occupies two
+// compile-time frame slots per entry — fetchOne's local and the inner
+// takeResult task's promise — plus, transiently, the child future's shared
+// state; an undersized stand-in undercounts every one of them.
 struct ParsedTab
 {
     QString id;
     QString name;
     QString type;
     std::vector<int> items;
+    std::byte pad[232]; // pad to sizeof(poe::StashWrapper) == 328
 };
 
 using ParsedOutcome = std::expected<ParsedTab, FetchError>;
+static_assert(sizeof(ParsedTab) == 328, "stand-in drifted from poe::StashWrapper");
+static_assert(sizeof(ParsedOutcome) == 336,
+              "stand-in outcome drifted from std::expected<poe::StashWrapper, FetchError>");
 
 // A pump queue entry (D1): request, endpoint label, capture timestamp,
 // promise, and the update's stop token.
@@ -230,7 +242,8 @@ static void drainCanceled(Update &u)
 
 // ---------------------------------------------------------------------------
 
-static void measureScale(int n, bool warmup)
+// Returns false if the run had to be abandoned (workers never finished).
+static bool measureScale(int n, bool warmup)
 {
     std::printf("\n[batch-scale measurement, N=%d%s]\n", n, warmup ? " (warm-up)" : "");
 
@@ -279,6 +292,20 @@ static void measureScale(int n, bool warmup)
     }
     check(allReady, "every handle reports ready before the sweep (sweep destroys completed only)");
 
+    if (u->stats.finished < n || !allReady) {
+        // An unfinished worker is still suspended holding pointers into *u.
+        // Destroying the update now would detach live frames (S1-1) that a
+        // later scale's event processing could resume into freed state —
+        // retain the update until process exit instead, and run no further
+        // scales.
+        std::printf("       measurement abandoned: %d/%d workers finished — leaking the update "
+                    "deliberately (sweeping now would detach live frames, S1-1/S1-4)\n",
+                    u->stats.finished,
+                    n);
+        (void) u.release();
+        return false;
+    }
+
     // --- deferred sweep (D6): destroy the completed handles ---
     t.restart();
     u->handles.clear();
@@ -316,6 +343,7 @@ static void measureScale(int n, bool warmup)
                 asMB(afterTeardown.heapInUse - base.heapInUse));
     std::printf("       footprint vs baseline:   after teardown %+.2f MB\n",
                 asMB(afterTeardown.footprint - base.footprint));
+    return true;
 }
 
 int main(int argc, char **argv)
@@ -348,7 +376,9 @@ int main(int argc, char **argv)
     }
 
     for (size_t i = 0; i < scales.size(); ++i) {
-        measureScale(scales[i], scales.size() > 1 && i == 0);
+        if (!measureScale(scales[i], scales.size() > 1 && i == 0)) {
+            break; // a leaked update must not meet another scale's event loop
+        }
     }
 
     std::printf("\n%d CHECK failure(s)\n", g_checkFailures);


### PR DESCRIPTION
Executes the network-redesign spec's remaining phasing-step-0 item: batch submission at the 2,000-tab scale — peak memory and abort cost for the full promise/future/frame/token population. Two review rounds are folded in (recorded as the S2 follow-up in the review history).

## What's here

- `spikes/qcoro/batch.cpp` (new target `qcoro_batch`): builds the spec's production topology per entry — pump deque entry (realistic `QNetworkRequest` with auth/UA headers and the 10 s transfer timeout, endpoint label, timestamp, `QPromise`, stop token), facade `.then(parse)` chain with no parent-future retention (D7/D2), eager per-fetch worker suspended on `co_await qCoro(child).takeResult()` with the post-await stop check (D6/IR2), handles in a worker-owned container (R4-3), one `stop_source` per update — then aborts the maximal standing population: `request_stop()` → drain completes each entry `Canceled` at the dequeue checkpoint → queued watcher resumptions → deferred sweep.
- The parsed-outcome stand-in is sized to the real facade payload: `sizeof(std::expected<poe::StashWrapper, FetchError>)` = 336 bytes probed against the actual headers (character wrapper: 744). The size is load-bearing — it occupies three compile-time frame slots per entry along the `takeResult` path (worker frame local, inner task's promise storage, awaiter move-out). The `static_assert`s pin the probed numbers, not the production types; re-probe manually if those change.
- Separate binary so measurement gets a fresh process (clean baselines, away from `qcoro_spike`'s deliberate leaks). Instrumented with `malloc_zone_statistics` + `task_vm_info`; scales configurable via argv (default 200 warm-up + 2,000). If workers ever fail to finish, the run deliberately leaks the update and stops — sweeping under still-suspended frames would be S1-1's detach-into-use-after-free.
- Findings recorded as round **S2** (+ follow-up) in `network-redesign-reviews.md`; the spec's status line, D6, and the phasing sketch cite it inline.

## Results (Release, Qt 6.11.1/macOS)

| What | Measured |
|---|---|
| Standing population | ~6.5 KB heap/entry, linear 200→2,000→10,000 (6542/6516/6520 B) |
| 2,000-tab population | ~12.4 MB heap, ~11–13 MB footprint |
| Abort total at 2,000 | ~2–4 ms (Canceled burst ~2.4 ms + resumptions ~1.1 ms + sweep ~0.3 ms) |
| Abort at 10,000 | ~13 ms |
| After sweep | heap back to baseline (+0.23 MB noise), `leaks --atExit`: **0 leaks** |
| Submit burst at 2,000 | ~8 ms synchronous |

The dominant abort latency is the one-time ~22 ms stop-interruptible sleep wake per pump (S1-5), not anything that scales with population. Scale also does not bend the S1 contracts: queued delivery held under the 2,000-completion burst, every post-await stop check fired, no parse ran on the abort path, all handles ready before the sweep. All checks pass plain and under ASAN.

## Review rounds folded

1. **Outcome sizing (P2):** the first cut's 104-byte synthetic outcome undercounted the population by ~0.7 KB/entry (three frame slots, not shared-state-only); re-measured with the real-sized stand-in — verdict unchanged.
2. **Timeout safety (P3):** the resumption-wait timeout path originally swept and destroyed the update under possibly-live frames; it now leaks deliberately and runs no further scales. A second pass corrected the slot-count comment and labeled the asserts as probe-pinned.

**Verdict: the numbers do not demand flow control, so none is designed; the deferred sweep needs no incremental reclamation. Phasing step 0 is closed** — next is the phase-1 manager harness (no QCoro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)