### PR TITLE
ci: install Inno Setup via chocolatey, pinned at 6.7.1

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -73,9 +73,10 @@ jobs:
 
     - name: Install Inno Setup
       run: |
-        $installer = "$env:TEMP\innosetup.exe"
-        Invoke-WebRequest -Uri "https://jrsoftware.org/download.php/is.exe" -OutFile $installer
-        Start-Process -FilePath $installer -ArgumentList "/VERYSILENT", "/NORESTART" -Wait
+        # Installed via chocolatey, pinned: the jrsoftware.org download.php
+        # URL has served an HTML page instead of the installer (observed
+        # July 2026), which silently produced a corrupt innosetup.exe.
+        choco install innosetup --version=6.7.1 -y --no-progress
         echo "${env:ProgramFiles(x86)}\Inno Setup 6" >> $env:GITHUB_PATH
 
     - name: Build installer


### PR DESCRIPTION
The Windows release workflow downloads Inno Setup from `https://jrsoftware.org/download.php/is.exe`, which currently 302-redirects to an HTML page (`/isdl.php`, ~10 KB of text/html). The workflow saves that HTML as `innosetup.exe` and the silent install fails with "corrupted and unreadable" — observed twice on [run 29711537256](https://github.com/gerwaric/acquisition/actions/runs/29711537256) and its retry. Every Windows release build fails at the *Install Inno Setup* step until that URL recovers.

This installs the checksummed chocolatey package instead, **pinned at 6.7.1** (current latest) so release packaging does not float with upstream.

Split out of #169 per review — CI/release supply chain changes shouldn't ride in a network-pipeline PR. **Merge this first**: #169's Windows dispatch fails at the packaging step (only) until this lands. The fix was verified end-to-end (unpinned) on [run 29712710924](https://github.com/gerwaric/acquisition/actions/runs/29712710924) before the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)