### PR TITLE
test: make test-helper preconditions unconditional

### DIFF
--- a/tests/fakenetwork.h
+++ b/tests/fakenetwork.h
@@ -101,7 +101,9 @@ public:
                  QNetworkReply::NetworkError error = QNetworkReply::NoError)
     {
         PendingRequest &pending = m_requests.at(i);
-        Q_ASSERT(pending.reply);
+        if (!pending.reply) {
+            qFatal("FakeRateLimiter::deliver: request %zu has no reply to complete", i);
+        }
         auto *network_reply = new FakeNetworkReply(pending.request, body, error);
         emit pending.reply->complete(network_reply);
     }

--- a/tests/fakesender.h
+++ b/tests/fakesender.h
@@ -37,7 +37,10 @@ public:
                 int http_status = 0,
                 QNetworkReply::NetworkError error = QNetworkReply::NoError)
     {
-        Q_ASSERT(!isFinished());
+        if (isFinished()) {
+            qFatal("InFlightReply::finish: reply for %s was already finished",
+                   qPrintable(url().toString()));
+        }
         for (const auto &header : headers) {
             setRawHeader(header.first, header.second);
         }

--- a/tests/mainwindowfixture.h
+++ b/tests/mainwindowfixture.h
@@ -43,7 +43,9 @@ public:
         // NetworkManager creates a disk cache in AppLocalDataLocation.
         QStandardPaths::setTestModeEnabled(true);
         InitializeMainWindowTestCategories();
-        Q_ASSERT(spdlog::get("main"));
+        if (!spdlog::get("main")) {
+            qFatal("MainWindowFixture: the 'main' logger was not registered");
+        }
 
         settings = std::make_unique<QSettings>(tempDir.filePath("settings.ini"),
                                                QSettings::IniFormat);

--- a/tests/testfixtures.h
+++ b/tests/testfixtures.h
@@ -83,7 +83,10 @@ inline Item makeTestItem(const char *json, const ItemLocation &loc)
 {
     const std::string_view input(json);
     auto item = glz::read_json<poe::Item>(input);
-    Q_ASSERT(item);
+    if (!item) {
+        qFatal("makeTestItem: could not parse the test item json: %s",
+               glz::format_error(item.error(), input).c_str());
+    }
     return Item(*item, loc);
 }
 

--- a/tests/tst_mainwindow.cpp
+++ b/tests/tst_mainwindow.cpp
@@ -99,7 +99,9 @@ static QLineEdit *findNameFilter(MainWindow &window)
 static QStringList visibleItemNames(const QTreeView &view)
 {
     const QAbstractItemModel *model = view.model();
-    Q_ASSERT(model);
+    if (!model) {
+        qFatal("visibleItemNames: the tree view has no model");
+    }
 
     QStringList names;
     for (int bucketRow = 0; bucketRow < model->rowCount(); ++bucketRow) {

--- a/tests/tst_workerparse.cpp
+++ b/tests/tst_workerparse.cpp
@@ -40,8 +40,12 @@ static poe::Item makePoeItem(const char *id)
     })")
                                 .arg(id)
                                 .toUtf8();
-    auto item = glz::read_json<poe::Item>(std::string_view(json.constData(), json.size()));
-    Q_ASSERT(item);
+    const std::string_view input(json.constData(), json.size());
+    auto item = glz::read_json<poe::Item>(input);
+    if (!item) {
+        qFatal("makeItem: could not parse the test item json: %s",
+               glz::format_error(item.error(), input).c_str());
+    }
     return *item;
 }
 


### PR DESCRIPTION
Follow-up to the review finding on #169, applied to the six remaining sites.

`Q_ASSERT` compiles out under `QT_NO_DEBUG`, and all three CI workflows configure `-DCMAKE_BUILD_TYPE=Release` — so every one of these checks was inert exactly where it mattered most. Verified rather than assumed: `Q_ASSERT(false)` built with `-DQT_NO_DEBUG -O2` against Qt 6.11.1 exits 0 and keeps running.

Each site guards a precondition whose violation in Release is worse than a failed assertion:

| Site | Consequence if false in Release |
|---|---|
| `testfixtures.h`, `tst_workerparse.cpp` | dereferences a failed `glz::expected` — undefined behavior |
| `fakenetwork.h`, `tst_mainwindow.cpp` | dereferences a null pointer |
| `fakesender.h` | double-emits `finished()`, silently corrupting the fake's semantics |
| `mainwindowfixture.h` | test proceeds without the `main` logger registered |

All six now test unconditionally and call `qFatal` with a message naming the helper and the offending value. The two JSON helpers report the underlying failure via `glz::format_error`, matching how `src/` already handles glaze errors (`json_readers.cpp:27`, `buyoutmanager.cpp:240`).

**Verification.** Full suite passes in both a default and a full Release build (19/19 each) with the checks live, so none false-fire. Forcing a parse failure in Release aborts with a genuinely useful diagnostic, attributed by Qt Test to the running test rather than dying opaquely:

```
QFATAL : WorkerParseTest::parsesCachedStashItems() makeItem: could not parse the test item json: 1:3: expected_quote
FAIL!  : WorkerParseTest::parsesCachedStashItems() Received a fatal error.
```

No `Q_ASSERT` now remains in `tests/` — the only textual match left is inside `fakescheduler.h`'s comment explaining why that check deliberately isn't one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)