### PR TITLE
Preserve league/realm selections when 'remember me' is unchecked

### DIFF
--- a/src/ui/logindialog.cpp
+++ b/src/ui/logindialog.cpp
@@ -142,7 +142,17 @@ LoginDialog::~LoginDialog()
         if (auto lg = spdlog::default_logger(); lg) {
             lg->trace("Login: clearing settings");
         }
+        // "Remember me" governs credentials only: preserve the league and
+        // realm selections, which are not credentials, across the clear.
+        const QVariant league = m_settings.value("league");
+        const QVariant realm = m_settings.value("realm");
         m_settings.clear();
+        if (league.isValid()) {
+            m_settings.setValue("league", league);
+        }
+        if (realm.isValid()) {
+            m_settings.setValue("realm", realm);
+        }
         m_datastore.Set("oauth_token", "");
     }
     delete ui;


### PR DESCRIPTION
## Intent

Follow-up to #180 (thanks for the quick merge and the alpha.3 release!). With private-league support in, one paper cut remains: closing the app with **remember me unchecked** runs `LoginDialog::~LoginDialog`'s `m_settings.clear()`, which wipes the league/realm selections along with the credentials — so the league must be retyped every session. For private leagues that's a hand-typed id like `My League (PL12345)` each time. (Root-caused from a real user report of exactly this retype loop.)

## Change (10 lines in the destructor)

Treat "remember me" as governing **credentials only**: snapshot `league`/`realm` before the clear and restore them after. Token wiping is unchanged, so the privacy behavior of unchecking the box is preserved — login is still required next session; only the non-credential league/realm choices survive, restored through the #180 path in `OnLeaguesReceived`.

## Tested

Built on top of current master (alpha.3) on macOS arm64; all 33 ctest tests pass. The destructor change is inspection-simple (snapshot/restore around the existing clear); happy to add whatever verification you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtLF9xL3JK3wez4d7ffE57