### PR TITLE
M3 spec: delta-native items model (frozen at revision 4)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,18 @@ when this map and a header disagree, the header wins.
 - `design/items-pipeline-m2-reviews.md` — that spec's review history:
   round-scoped finding tables (`R1-*`, …) with verdicts and
   resolutions, round narratives, and the revision log.
+- `design/items-pipeline-m3.md` — **draft** spec (revision 1,
+  July 30, 2026, in review) for Milestone 3, the delta-native items
+  model: bucket-scoped model operations replacing the refresh-path
+  reset, precomputed cached sort keys plus deferred bucket sorting
+  (the July 30 lever hold point), the By-Item per-delta merge, and
+  the F67 tie-break fix. Pre-spec evidence:
+  `design/m3-sort-profile-result.md` (S1-M3 spike, run on the
+  never-merged branch `spike/m3-sort-profile`, including the
+  hold-point key-memory extension). The M1-M3 budget measurement
+  runs as an implementation checkpoint.
+- `design/items-pipeline-m3-reviews.md` — that spec's review history
+  and revision log; rounds recorded from round 1 (none yet).
 - `design/items-pipeline-m2-implementation.md` — **accepted**
   implementation sequence for the frozen M2 spec (externally
   reviewed July 29, three findings incorporated): stage boundaries,

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,9 +20,9 @@ when this map and a header disagree, the header wins.
 - `design/items-pipeline-m2-reviews.md` — that spec's review history:
   round-scoped finding tables (`R1-*`, …) with verdicts and
   resolutions, round narratives, and the revision log.
-- `design/items-pipeline-m3.md` — **draft** spec (revision 2,
-  July 30, 2026, in review; round 1's eight findings incorporated)
-  for Milestone 3, the delta-native items model: bucket-scoped model operations replacing the refresh-path
+- `design/items-pipeline-m3.md` — **draft** spec (revision 3,
+  July 30, 2026, in review; rounds 1–2's fourteen findings
+  incorporated) for Milestone 3, the delta-native items model: bucket-scoped model operations replacing the refresh-path
   reset, precomputed cached sort keys plus deferred bucket sorting
   (the July 30 lever hold point), the By-Item per-delta merge, and
   the F67 tie-break fix. Pre-spec evidence:
@@ -31,7 +31,8 @@ when this map and a header disagree, the header wins.
   hold-point key-memory extension). The M1-M3 budget measurement
   runs as an implementation checkpoint.
 - `design/items-pipeline-m3-reviews.md` — that spec's review history
-  and revision log; round 1 recorded (R1-1…R1-8, all accepted).
+  and revision log; rounds 1–2 recorded (R1-1…R1-8, R2-1…R2-6, all
+  accepted).
 - `design/items-pipeline-m2-implementation.md` — **accepted**
   implementation sequence for the frozen M2 spec (externally
   reviewed July 29, three findings incorporated): stage boundaries,

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,9 +20,9 @@ when this map and a header disagree, the header wins.
 - `design/items-pipeline-m2-reviews.md` — that spec's review history:
   round-scoped finding tables (`R1-*`, …) with verdicts and
   resolutions, round narratives, and the revision log.
-- `design/items-pipeline-m3.md` — **draft** spec (revision 1,
-  July 30, 2026, in review) for Milestone 3, the delta-native items
-  model: bucket-scoped model operations replacing the refresh-path
+- `design/items-pipeline-m3.md` — **draft** spec (revision 2,
+  July 30, 2026, in review; round 1's eight findings incorporated)
+  for Milestone 3, the delta-native items model: bucket-scoped model operations replacing the refresh-path
   reset, precomputed cached sort keys plus deferred bucket sorting
   (the July 30 lever hold point), the By-Item per-delta merge, and
   the F67 tie-break fix. Pre-spec evidence:
@@ -31,7 +31,7 @@ when this map and a header disagree, the header wins.
   hold-point key-memory extension). The M1-M3 budget measurement
   runs as an implementation checkpoint.
 - `design/items-pipeline-m3-reviews.md` — that spec's review history
-  and revision log; rounds recorded from round 1 (none yet).
+  and revision log; round 1 recorded (R1-1…R1-8, all accepted).
 - `design/items-pipeline-m2-implementation.md` — **accepted**
   implementation sequence for the frozen M2 spec (externally
   reviewed July 29, three findings incorporated): stage boundaries,

--- a/docs/cleanup/findings.md
+++ b/docs/cleanup/findings.md
@@ -127,6 +127,29 @@ of proportion to the risk; this finding is the hook if a collision
 ever materializes or the stores are otherwise reworked (M3 is the
 natural opportunity).
 
+### F67. `Item::operator<` compares `m_hash` against itself — Confirmed; harmless today
+
+Found July 30, 2026, while reading the sort path for the M3
+sort-profiling spike (`docs/design/m3-sort-profile-result.md`). The
+tie-break tuple in `Item::operator<` (`item.cpp`) is
+
+```cpp
+return std::tie(name, m_uid, m_hash) < std::tie(rhs_name, rhs.m_uid, m_hash);
+```
+
+— the third element is the *left-hand* item's `m_hash` on both sides
+(should be `rhs.m_hash`), so the hash term always compares equal and
+is dead code. The ordering is still a valid strict weak ordering:
+`(PrettyName, m_uid)` decides, and two items tying on both (possible
+only when both lack a server id, since `m_uid` is the GGG item id)
+compare equivalent. Consequence is only that the intended
+hash-level determinism for id-less items does not exist; no
+user-visible misbehavior is known. Fix is a one-token change
+(`rhs.m_hash`) whenever the comparator is next touched — M3's sort
+work is the natural opportunity; a precomputed-sort-key design must
+decide whether to reproduce the intended `(name, uid, hash)` order
+or the actual `(name, uid)` one.
+
 ## Standing constraints and lessons
 
 Rules distilled from resolved findings that remain binding on future work.

--- a/docs/design/items-pipeline-m3-reviews.md
+++ b/docs/design/items-pipeline-m3-reviews.md
@@ -15,7 +15,50 @@ cites findings by number; this file is the record.
   `(name, uid, hash)` tie-break order (D5, fixing F67), and the
   key-memory measurement run pre-freeze as a spike extension
   (~286 B/item accounted, ~266 MB naive at 1m). No review rounds yet.
+- **Revision 2 (July 30, 2026)** — round 1 incorporated (external
+  review, eight findings R1-1…R1-8, all verified against the code and
+  accepted; none challenged the hold-point decisions). Key changes:
+  content deltas erase **source-scoped** within the stable-key display
+  bucket (R1-1); the final snapshot performs authoritative **row**
+  reconciliation, covering deletions and new unfetched tabs (R1-2);
+  selection becomes an *intent* keyed by stable item id that survives
+  mid-refresh removal and is re-adopted globally (R1-3); the
+  intersection contract gains a metadata half, retiring M2 R7-2's
+  metadata-only exception (R1-4); the key/sortedness state machine is
+  specified with **transient** By-Tab keys and resident keys only for
+  By-Item — a simplification that also shrinks the memory story
+  (R1-5); buyout invalidation gains a batching/observability contract
+  and the migration paths (R1-6); deltas the active search applies
+  leave it clean, renegotiating M2 D9 rule 1 for the active search
+  only (R1-7); the broad-filter default-expanded worst case is
+  documented and budgeted (R1-8).
 
-## Round 1
+## Round 1 (July 30, 2026 — external review of revision 1)
 
-Not yet run.
+Eight findings, all **accepted** after claim-by-claim verification
+(M2 D2/D6/D9/R6-3 texts; `buyoutmanager.cpp:369` (`MigrateItem`),
+`search.cpp:261-290`, `column.cpp`). None challenges the settled
+lever or tie-break decisions.
+
+| # | Severity | Finding | Verdict and resolution |
+|---|---|---|---|
+| R1-1 | High | D3 confused fetch-source replacement with display-bucket replacement: a Map/Unique child delta, applied as "replace the bucket's rows", would erase sibling sources sharing the parent display bucket — contradicting M2 D2's accepted mixed-generation behavior. | Accepted. Verified against M2 D2 (atomic unit = fetch source) and D6/R5-1 (buckets key on stable `(type, id)`, aggregating sources). D3's replacement is now **source-scoped within the display bucket**: erase exactly the rows whose items were fetched from the delta's `FetchSourceKey`, insert the arrivals; sibling sources untouched. Source-scoped erase (over rebuild-from-published) chosen because it stays within the signal payload and mirrors the reconciliation's erase-by-predicate shape. New pin `childDeltaPreservesSiblingSourcesInParentBucket`. |
+| R1-2 | High | The final reconciliation (metadata + moves only) omitted final-only additions and deletions: M2 D6 keeps deleted tabs (with items) and newly discovered unfetched tabs snapshot-boundary-only, so no delta removes/inserts them and the model would retain deleted content and miss new empty tabs. | Accepted. Verified against M2 D6's publication table. The final snapshot now performs **authoritative row reconciliation**: one pass diffing the model against the post-snapshot published state per stable key — deleted buckets/rows removed, newly listed tabs inserted (unfiltered searches), metadata refreshed, bucket order fixed by moves; row operations only, never a reset. New pins `finalReconciliationRemovesDeletedTabs`, `finalReconciliationInsertsNewlyListedEmptyTabs`. |
+| R1-3 | High | Immediate remove-then-insert application loses M2 R6-3's global cross-tab selection fidelity: when the removal delta arrives before the insertion delta, naive clearing breaks `reselectionSurvivesCrossTabMove`; `byItemSelectionSurvivesMerge` as drafted said "removed clears" immediately. | Accepted. Verified against M2 R6-3 (global identity lookup, cross-tab pin). D3 gains a **selection-intent contract**: intent is keyed by stable item id, survives row removal during an active refresh, is re-adopted globally when any later delta inserts the id, and is cleared at the final reconciliation if the id is absent or by user action; outside an active refresh, removal clears immediately. New pin `selectionIntentSurvivesCrossTabMoveAcrossDeltas` (the M2 pin's successor under no-reset machinery); `byItemSelectionSurvivesMerge` reworded accordingly. |
+| R1-4 | High | D3 promised immediate new-tab insertion and rename/move/color updates but inherited M2's item-based intersection gate, which deliberately excludes metadata-only (empty) deltas — post-M3 those would wait indefinitely, especially after terminal failure (no throttled tick, no guaranteed refilter). | Accepted. Verified against M2 D6 ("D9 deliberately has no metadata-only intersection trigger") and R7-2. The intersection contract gains a **metadata half**: every delta's location anchor lands in the canonical inventory immediately (existing M2 machinery), and a delta whose stable key owns a visible bucket — or would create one in an unfiltered search — applies metadata now (`dataChanged`, moves, empty-bucket insertion), item intersection notwithstanding. M2 R7-2's exception is explicitly renegotiated and retired. New pin `metadataDeltaAppliesWithoutItemIntersection` (empty rename/move/color/new-tab, no final snapshot, persisting after terminal failure). |
+| R1-5 | Medium-high | The lazy bucket/key state machine was incomplete and internally inconsistent: D1 said collapsed buckets hold no keys, D2 said they retain arrival order; expand → sort → collapse left key eviction, order retention, and arrival-order reconstruction unspecified, and each candidate resolution broke a stated claim. | Accepted, resolved by simplification: **By-Tab keys are transient sorting scratch** (built for a sort, discarded after; what persists is the bucket's order and a sorted-validity flag), and **resident keys exist only for the By-Item flat bucket** (D4 needs them for merges). Collapse changes nothing (order and flag persist; arrival order is never reconstructed); invalidation acts on flags, not caches. D1/D2 now state the full transition table (expand, collapse, delta, column switch, direction flip, buyout invalidation). Strengthens the memory claim: resident key memory is By-Item only; By-Tab peak is one bucket (~0.2 MB). New pins `sortedOrderSurvivesCollapse`, `byTabKeysAreTransient`; `sortColumnSwitchRebuildsMaterializedKeysOnly` superseded by `sortColumnSwitchResortsVisibleBucketsOnly`. |
+| R1-6 | Medium-high | The buyout invalidation contract lacked observability and batching: no statement of when a visible bucket reorders, how Price/Date **cells** repaint when another column is active, whether migration (`MigrateItem`/`MigrateTab`) counts as mutation, or how bulk pricing passes avoid one reorder per `Set` (quadratic risk on the flat bucket). | Accepted. Verified `MigrateItem` at `buyoutmanager.cpp:369` mutates the lookup result. D1 rule 4 now specifies: the choke-point inventory includes item/tab set-and-clear, **migration**, and the scoped and final pricing passes; pricing passes batch — one invalidation batch, hence at most one reorder/model update per pass; user edits apply immediately; and Price/Date cells repaint via `dataChanged` for affected visible rows regardless of the active sort column (reordering alone is gated on the active column). New pins `pricingPassYieldsSingleModelUpdate`, `priceCellsRepaintUnderAnySortColumn`; `priceKeysFollowBuyoutEdits` extended to migration. |
+| R1-7 | Medium | Inheriting M2 D9 rule 1 unchanged makes the active search dirty on every delta it just applied, so switching away and back triggers a spurious full refilter; the final reconciliation didn't clear the flag either. | Accepted. Verified against M2 D9 rule 1's wording. Renegotiated **for the active search only**: a delta the active search applied — including one correctly adjudicated as no visible change — leaves it clean; any skipped application leaves it dirty (fail-safe); the final reconciliation clears it. Background searches keep rule 1 verbatim. New pin `appliedDeltasLeaveActiveSearchClean`. |
+| R1-8 | Medium | "Filtered results are small by construction" is not a bound: a broad filter can match nearly the whole collection while default-expanding every bucket, approaching full keyed sorting — a case no budget covered. | Accepted. Verified `m_filtered` semantics (`search.cpp:261-290` — any excluded item sets it). D2 drops the claim and states the honest ceiling (key build + sort of ~everything atop the filter loop, ~0.9 s estimated at 1m; memory unaffected under R1-5's transient keys). M1-M3 gains a broad-filter default-expanded scenario with a ≤ 1.2 s budget at 1m. |
+
+Round narrative: the round's through-line is that revision 1
+specified the delta path's *happy* grain (one content delta, one
+visible By-Tab bucket) and under-specified the boundaries — source
+vs. display-bucket grain (R1-1), snapshot-boundary effects (R1-2),
+cross-delta state (R1-3), metadata-only deltas (R1-4), state-machine
+transitions (R1-5), batching (R1-6). The lesson mirrors M2 round 2's:
+contracts that hold at the single-event grain must be re-checked at
+the sequence grain (two deltas in flight, a pass of many mutations, a
+whole refresh). One finding (R1-5) was resolved by simplifying the
+design rather than adding state — transient keys retire the cache
+lifetime questions instead of answering them.

--- a/docs/design/items-pipeline-m3-reviews.md
+++ b/docs/design/items-pipeline-m3-reviews.md
@@ -33,6 +33,22 @@ cites findings by number; this file is the record.
   only (R1-7); the broad-filter default-expanded worst case is
   documented and budgeted (R1-8).
 
+- **Revision 3 (July 30, 2026)** — round 2 incorporated (external
+  review of revision 2, six findings R2-1…R2-6, all verified and
+  accepted; R1-2/R1-4/R1-7/R1-8's resolutions confirmed adequate).
+  Key changes: the selection-intent window closes on **every**
+  `RefreshFinished` outcome, failure included (R2-1); visible
+  multi-source buckets get a remove-runs + sorted-merge-insert-runs
+  contract, and D3's O(1) batch claim is corrected to O(runs)
+  (R2-2); **By-Tab key residency is restored** for the active
+  search's materialized buckets — round 1's transient-key resolution
+  had silently altered the hold point's cached-key choice, and
+  revision 3 specifies eviction/invalidation *within* the settled
+  choice instead (R2-3); key residency is scoped to the active
+  search, with lazy rebuild on reactivation (R2-4); user buyout
+  commands batch at command scope (R2-5); three stale references
+  fixed, including the nonexistent `MigrateTab` (R2-6).
+
 ## Round 1 (July 30, 2026 — external review of revision 1)
 
 Eight findings, all **accepted** after claim-by-claim verification
@@ -61,4 +77,34 @@ contracts that hold at the single-event grain must be re-checked at
 the sequence grain (two deltas in flight, a pass of many mutations, a
 whole refresh). One finding (R1-5) was resolved by simplifying the
 design rather than adding state — transient keys retire the cache
-lifetime questions instead of answering them.
+lifetime questions instead of answering them. *(Round 2 note: that
+resolution overstepped — see R2-3, which reversed the transient-key
+choice for By-Tab while keeping the flag machinery it introduced.)*
+
+## Round 2 (July 30, 2026 — external review of revision 2)
+
+Six findings, all **accepted** after verification (`MigrateTab`'s
+nonexistence and the `OnBuyoutChange` multi-row loop
+(`ui/mainwindow.cpp:541-567`) confirmed in code; R2-1/R2-2 confirmed
+against the revision-2 contracts; R2-3 confirmed against the
+hold-point record). The round also confirmed R1-2, R1-4, R1-7, and
+R1-8 as adequately resolved.
+
+| # | Severity | Finding | Verdict and resolution |
+|---|---|---|---|
+| R2-1 | High | The selection-intent window ran from first delta to final reconciliation, but `FailedRefresh` emits no final snapshot (M2 D4) — after a failed refresh an absent item's intent could survive into a later refresh and unexpectedly reselect it. | Accepted. The intent window now closes on **every** `RefreshFinished` outcome: success closes it at the final reconciliation; failure performs the absence check against the visible result at the terminal event itself. New pin `selectionIntentClearsOnTerminalFailure`. |
+| R2-2 | High | Source-scoped removal preserves siblings, but sorting the arrivals alone cannot establish a visible multi-source bucket's global order — arrivals must merge into the retained sibling rows; and D3's "O(1) row-op batches" claim contradicted the O(runs) reality D4 already acknowledged. | Accepted. D3 now specifies remove-runs plus sorted-merge insert-runs for visible multi-source buckets (O(runs) model operations, O(bucket) work) and the batch-count claim is corrected to O(runs), O(1) in the common single-source case. `childDeltaPreservesSiblingSourcesInParentBucket` extended with heavily interleaved keys and persistent-index assertions. |
+| R2-3 | High | Revision 2's transient-By-Tab-keys resolution (R1-5) silently changed the hold point's **cached**-key lever: direction flips and invalidations now rebuilt keys instead of reusing them, altering a settled decision rather than specifying its lifecycle. | Accepted — the finding restores the settled choice. Key residency returns for the active search's materialized buckets (expanded By-Tab and the By-Item flat bucket): keys persist across re-sorts and direction flips; **collapse evicts keys while order and flag persist** (safe, because invalidation acts on flags independently of key residency — answering R1-5's original question within the cached design); column switches discard. The broad-filter fully-expanded memory ceiling (~a full-collection footprint) is now stated and budgeted. New pin `keyResidencyFollowsMaterialization`; `byTabKeysAreTransient` retired. |
+| R2-4 | Medium | By-Item key residency across view/search switches was unspecified: "while that view is active" never defined active, and N background By-Item searches could each hold ~222–266 MB. | Accepted, generalized to all resident keys: **residency is scoped to the active search** — deactivation evicts every key vector (orders and flags persist); reactivation rebuilds lazily at the next event that needs keys, not eagerly. At most one search holds resident keys at any time. New pin `residentKeysScopedToActiveSearch` (aggregate-memory assertion across multiple searches, By-Item included). |
+| R2-5 | Medium | "User edits apply immediately" still permitted one reorder per `Set`: `OnBuyoutChange` loops every selected row and then propagation runs, recreating in one command the quadratic behavior R1-6's pass-batching prevents. | Accepted. Verified the loop at `ui/mainwindow.cpp:541-567`. "Immediate" is redefined as **one batch at user-command end**; per-`Set` reordering is forbidden at every batch boundary (pass or command). New pin `multiSelectionBuyoutEditReordersOnce`. |
+| R2-6 | Low | Three stale references: D3 still called the intersection machinery "unchanged" despite the metadata half; traceability still said "one-bucket replace chosen" despite R1-1; and `MigrateTab` was named and pinned but does not exist (only `MigrateItem` does). | Accepted. All three corrected; the round-1 table's `MigrateTab` mentions stand as historical record, corrected here. The choke-point inventory now names `MigrateItem` alone and notes there is no tab-level migration. |
+
+Round narrative: rounds 1 and 2 form a pair — round 1 pushed the
+spec from event grain to sequence grain, and round 2 caught the
+places where round 1's own resolutions were under-specified at their
+boundaries (intent lifetime at the failure terminal, merge order in
+multi-source buckets, residency across searches) or overstepped
+(R2-3). The R2-3 lesson is a process one, worth keeping: a review
+resolution may simplify *within* a settled decision, but changing
+the settled decision itself — however defensible on the merits —
+belongs to a hold point, not a revision.

--- a/docs/design/items-pipeline-m3-reviews.md
+++ b/docs/design/items-pipeline-m3-reviews.md
@@ -1,0 +1,21 @@
+# Items Pipeline Milestone 3: Review Findings
+
+Review-round findings for `items-pipeline-m3.md`, recorded from
+round 1 per the M2 convention: each finding gets an `R<round>-<n>`
+number, a verdict (accepted / rejected / amended, with reasons), and
+a resolution naming the decision or criterion it changed. The spec
+cites findings by number; this file is the record.
+
+## Revision log
+
+- **Revision 1 (July 30, 2026)** — initial draft. Written after the
+  S1-M3 sort-profiling spike (evidence in `m3-sort-profile-result.md`)
+  and the same-day lever hold point, whose decisions it records:
+  levers A + B both committed (D1, D2), the intended
+  `(name, uid, hash)` tie-break order (D5, fixing F67), and the
+  key-memory measurement run pre-freeze as a spike extension
+  (~286 B/item accounted, ~266 MB naive at 1m). No review rounds yet.
+
+## Round 1
+
+Not yet run.

--- a/docs/design/items-pipeline-m3-reviews.md
+++ b/docs/design/items-pipeline-m3-reviews.md
@@ -66,6 +66,16 @@ cites findings by number; this file is the record.
   four-pass pricing sequence is **required** to emit one model
   batch (R3-4). The round was a consistency pass over revision 3's
   restored cache, not a re-litigation of any settled decision.
+- **FROZEN (July 30, 2026, at revision 4)** — Tom froze the spec
+  after round 3's reviewers judged it at diminishing returns and
+  the focused consistency check they prescribed (key residency,
+  activation ordering, nested batching — run as a scoped
+  fresh-eyes pass over the full document) surfaced only
+  wording-level findings, all folded into revision 4 pre-commit.
+  The review series is closed. Post-freeze changes follow the M2
+  convention: recorded amendments with reasons, never silent
+  edits. Production implementation proceeds against revision 4,
+  with M1-M3 as the completion gate.
 
 ## Round 1 (July 30, 2026 — external review of revision 1)
 

--- a/docs/design/items-pipeline-m3-reviews.md
+++ b/docs/design/items-pipeline-m3-reviews.md
@@ -49,6 +49,24 @@ cites findings by number; this file is the record.
   commands batch at command scope (R2-5); three stale references
   fixed, including the nonexistent `MigrateTab` (R2-6).
 
+- **Revision 4 (July 30, 2026)** — round 3 incorporated (external
+  review of revision 3, four findings R3-1…R3-4, all verified and
+  accepted, plus two review clarifications accepted into the
+  resolutions; R2-1/R2-2/R2-5/R2-6 confirmed closed, the
+  selection-terminal and interleaved-merge contracts confirmed
+  adequate). Key changes: key residency becomes an axis independent
+  of sorted validity, with one hydration rule for the
+  sorted-but-keyless state and an eager-at-activation carve-out for
+  clean By-Item searches — activation decides dirtiness first
+  (R3-1); the invalidation contract drops revision 2's "By-Tab key
+  caches don't exist" fossil and states each cause's effect on
+  every resident key vector (R3-2); nested pass/command batches
+  coalesce and only the outermost boundary emits (R3-3); migration
+  is re-pinned to its real batch boundary and the snapshot's
+  four-pass pricing sequence is **required** to emit one model
+  batch (R3-4). The round was a consistency pass over revision 3's
+  restored cache, not a re-litigation of any settled decision.
+
 ## Round 1 (July 30, 2026 — external review of revision 1)
 
 Eight findings, all **accepted** after claim-by-claim verification
@@ -108,3 +126,37 @@ multi-source buckets, residency across searches) or overstepped
 resolution may simplify *within* a settled decision, but changing
 the settled decision itself — however defensible on the merits —
 belongs to a hold point, not a revision.
+
+## Round 3 (July 30, 2026 — external review of revision 3)
+
+Four findings, all **accepted** after verification
+(`OnBuyoutChange`'s trailing `PropagateTabBuyouts` call confirmed at
+`ui/mainwindow.cpp:578`; `MigrateBuyouts` confirmed to run from
+snapshot processing at `itemsmanager.cpp:152`, sequenced with the
+auto-buyout and propagation passes at `itemsmanager.cpp:152-155`;
+R3-1/R3-2 confirmed against the revision-3 texts). The round also
+confirmed R2-1, R2-2, and R2-6 cleanly closed, R2-5's outcome
+correct pending R3-3's nesting rule, and the selection-terminal and
+interleaved multi-source merge contracts adequate. Review of the
+proposed resolutions added two clarifications, both accepted and
+folded in below.
+
+| # | Severity | Finding | Verdict and resolution |
+|---|---|---|---|
+| R3-1 | High | Eviction creates a sorted-but-keyless state later rules don't handle: re-expanding a valid bucket builds no keys, yet a direction flip promised resident-key reuse; worse, a reactivated clean By-Item search is visible but keyless, so the first delta merge would absorb a ~368 ms key build at 1m — contradicting D4's "keys resident" premise and the ≤ 50 ms delta budget. | Accepted. Residency and sorted validity are now independent axes with sorted-but-keyless a named state. One **hydration rule**: any key-consuming operation (flip re-sort, delta merge, buyout reorder) hydrates missing keys first — By-Tab bounded by the 576 cap, lazy per bucket. **By-Item hydrates eagerly at activation** (deliberate carve-out from R2-4's lazy rule: the flat bucket is always visible and sorted, so hydration is never speculative, and the cost lands on the user action that activated the view, not on a background delta). Review clarification, accepted: **activation decides dirtiness first** — a dirty search refilters once and that rebuild supplies the keys; only a clean search hydrates, so stale keys are never hydrated and immediately rebuilt. New pins `reexpandedBucketFlipHydratesOnce`, `byItemActivationDecidesDirtinessFirst`; new budget line (clean By-Item reactivation ≤ 0.5 s at 1m); D1 rule 3, D2 rules 2/7, D4 rule 1, and two existing residency pins reworded. |
+| R3-2 | High | The invalidation contract retained revision 2's "never on By-Tab key caches, which don't exist" after revision 3 restored resident By-Tab keys — an expanded Price/Date-sorted bucket could clear its flag and then re-sort on stale resident keys. | Accepted — a straight revision-2 fossil, now load-bearing and wrong. The contract preamble covers **every resident key vector, By-Tab and By-Item alike**, and each cause states its key effect: deltas discard the replaced source's entries and add arrivals' entries via the merge; column switches discard everything; buyout batches rebuild affected entries of Price/Date-sorted materialized buckets' vectors before the reorder (other columns: keys untouched, cells still repaint). `priceKeysFollowBuyoutEdits` extended to name the expanded By-Tab bucket explicitly. |
+| R3-3 | Medium | Nested buyout batches were contradictory: a user command must emit one batch at command end, but its trailing `PropagateTabBuyouts` call is itself a pricing pass required to emit at pass end — permitting an inner propagation update plus an outer command update. | Accepted. Verified the call at `ui/mainwindow.cpp:578`. New batching rule: **nested pass/command batches coalesce; only the outermost boundary emits** — an inner boundary inside an open batch accumulates into it. `multiSelectionBuyoutEditReordersOnce` extended to include the propagation call in the exercised command. |
+| R3-4 | Low | `priceKeysFollowBuyoutEdits` grouped migration with user edits "at command end," but `MigrateItem` runs from `ItemsManager::MigrateBuyouts` during snapshot processing — no user command exists there. | Accepted. Migration re-pinned inside the snapshot's outer batch (`itemsmanager.cpp:152`) — with that batch required (below), it is always migration's containing batch. Review clarification, accepted (upgrading the draft resolution's MAY to a requirement): the snapshot's `MigrateBuyouts` → `ApplyAutoTabBuyouts` → `ApplyAutoItemBuyouts` → `PropagateTabBuyouts` sequence **must** run as one outer model-invalidation batch — nothing observes UI state between the passes, and four separate batches could mean several full By-Item reorders; persistence writes unchanged. New pin `snapshotPricingSequenceEmitsOneModelBatch`. |
+
+Round narrative: round 3 is the settling round — no new contracts,
+no renegotiations, only the reconciliation of revision 3's restored
+key cache with the rules written around its predecessor (R3-1,
+R3-2) and the closing of the batching boundaries' composition
+(R3-3, R3-4). Both High findings trace to the same root: R2-3
+restored residency, and the surrounding text was only partially
+re-derived against it. The round's two clarifications sharpen
+resolutions rather than reopen them, and the reviewers judged the
+spec at diminishing returns: revision 4 warrants a focused
+consistency check of key residency, activation ordering, and nested
+batching — not another broad exploratory round — and freezes if
+that passes.

--- a/docs/design/items-pipeline-m3.md
+++ b/docs/design/items-pipeline-m3.md
@@ -1,8 +1,15 @@
 # Items Pipeline Milestone 3: Delta-Native Items Model
 
-Status: **DRAFT, revision 4** (July 30, 2026). In review, not
-frozen; production implementation must not begin against this
-document. Review rounds 1–3 (external; R1-1…R1-8, R2-1…R2-6, and
+Status: **FROZEN at revision 4** (July 30, 2026). Production
+implementation may begin against this document; M1-M3 (the
+performance/memory checkpoint in the acceptance criteria) gates M3
+completion. Frozen on Tom's decision after the round-3 reviewers
+judged the spec at diminishing returns and the prescribed focused
+consistency check (key residency, activation ordering, nested
+batching) passed with only wording-level findings, folded into
+revision 4 before it was committed. Post-freeze changes follow the
+M2 convention: recorded amendments with reasons, never silent
+edits. Review rounds 1–3 (external; R1-1…R1-8, R2-1…R2-6, and
 R3-1…R3-4, all eighteen verified and accepted) are incorporated
 throughout. Round 1's largest changes: D3's source-scoped
 replacement grain (R1-1), the final snapshot's row reconciliation

--- a/docs/design/items-pipeline-m3.md
+++ b/docs/design/items-pipeline-m3.md
@@ -1,18 +1,25 @@
 # Items Pipeline Milestone 3: Delta-Native Items Model
 
-Status: **DRAFT, revision 3** (July 30, 2026). In review, not
+Status: **DRAFT, revision 4** (July 30, 2026). In review, not
 frozen; production implementation must not begin against this
-document. Review rounds 1–2 (external; R1-1…R1-8 and R2-1…R2-6, all
-fourteen verified and accepted) are incorporated throughout. Round
-1's largest changes: D3's source-scoped replacement grain (R1-1),
-the final snapshot's row reconciliation (R1-2), the selection-intent
-contract (R1-3), the metadata half of the intersection contract
-(R1-4). Round 2 closed the boundaries round 1 opened — the intent
-window now ends at every terminal outcome (R2-1), multi-source
-buckets merge rather than merely sort arrivals (R2-2), and **key
-residency was restored to the hold point's cached-key choice**
-after round 1's transient-key resolution overstepped it (R2-3, with
-residency scoped to the active search per R2-4). Unlike M2, the pre-spec evidence is already in hand: the
+document. Review rounds 1–3 (external; R1-1…R1-8, R2-1…R2-6, and
+R3-1…R3-4, all eighteen verified and accepted) are incorporated
+throughout. Round 1's largest changes: D3's source-scoped
+replacement grain (R1-1), the final snapshot's row reconciliation
+(R1-2), the selection-intent contract (R1-3), the metadata half of
+the intersection contract (R1-4). Round 2 closed the boundaries
+round 1 opened — the intent window now ends at every terminal
+outcome (R2-1), multi-source buckets merge rather than merely sort
+arrivals (R2-2), and **key residency was restored to the hold
+point's cached-key choice** after round 1's transient-key
+resolution overstepped it (R2-3, with residency scoped to the
+active search per R2-4). Round 3 reconciled the restored cache's
+remaining inconsistencies: residency became an explicit axis with a
+single hydration rule and an eager-at-activation carve-out for
+By-Item (R3-1), invalidation now covers every resident key vector
+(R3-2), nested buyout batches emit only at the outermost boundary
+(R3-3), and migration is pinned at its true batch boundary, with
+the snapshot's pricing sequence required to emit one batch (R3-4). Unlike M2, the pre-spec evidence is already in hand: the
 parent plan's "profile before choosing levers" obligation was
 discharged by the S1-M3 sort-profiling spike (July 30, 2026, branch
 `spike/m3-sort-profile`, evidence in `m3-sort-profile-result.md`
@@ -136,36 +143,64 @@ item lives. Both facts are measured (spike section 4).
 **Residency: keys are cached for the active search's materialized
 buckets (R2-3, R2-4 — the hold point's cached-key choice, with its
 lifecycle specified).** A *materialized* bucket is an expanded
-By-Tab bucket or the By-Item flat bucket. The rules:
+By-Tab bucket or the By-Item flat bucket. **Key residency and
+sorted validity are independent axes (R3-1)**: eviction removes
+keys while order and flag persist, so *sorted-but-keyless* is a
+legitimate, explicitly handled state, not a gap. The rules:
 
 - Within the **active search**, a materialized bucket keeps its key
   vector resident from its first sort until evicted — re-sorts and
   direction flips reuse it without rebuilding (the spike's 40×
   cached path), and a bucket whose sorted flag is valid skips
   sorting entirely (D2's flags — stronger still).
+- **Hydration rule (R3-1): any operation that consumes keys — a
+  direction flip's re-sort, a delta's merge, a buyout batch's
+  reorder — hydrates missing keys first**, an O(bucket) build. For
+  a By-Tab bucket this is bounded by the 576-item cap
+  (microseconds keyed). There is no other hydration path: a
+  sorted-but-keyless bucket stays keyless until one of these
+  events actually needs its keys; nothing pre-builds
+  speculatively.
 - **Collapse evicts the bucket's keys; its order and sorted flag
   persist.** This is safe against later Price/Date staleness because
   invalidation acts on flags independently of key residency — the
   question R1-5 raised, now answered *within* the cached design.
+  Re-expanding while the flag is valid does no work (D2 rule 2),
+  leaving the bucket sorted-but-keyless; the next key-consuming
+  event hydrates it by the rule above.
 - **Residency is scoped to the active search (R2-4).** Deactivating
   a search evicts every one of its key vectors (orders and flags
-  persist); reactivation rebuilds **lazily**, at the next event that
-  actually needs keys (an invalidated sort, a merge), never eagerly.
-  At most one search holds resident keys at any time — N background
-  By-Item searches hold none, not ~250 MB each.
+  persist). **Reactivation decides dirtiness first (R3-1)**: a
+  dirty search refilters once, and that rebuild supplies its keys —
+  never a hydration of stale keys immediately before rebuilding
+  them. A clean search's By-Tab buckets rehydrate lazily,
+  per bucket, by the hydration rule; but **a clean By-Item search
+  hydrates its flat bucket's keys eagerly at activation**, before
+  any delta can need them. The eager carve-out is deliberate: the
+  flat bucket is always visible and always sorted (D4), so its
+  hydration is never speculative, and paying it at activation
+  (~368 ms at 1m, budgeted below) attributes the unavoidable
+  rebuild to the user action that made the view active — instead
+  of letting the first background delta absorb it and blow the
+  ≤ 50 ms merge budget. At most one search holds resident keys at
+  any time — N background By-Item searches hold none, not ~250 MB
+  each.
 - Build cost is O(bucket) — measured 33 ms per 100k items, 368 ms
-  per 1m, so a 576-item bucket keys in well under a millisecond, and
-  a lazy rebuild after reactivation costs only what it re-sorts.
+  per 1m, so a 576-item bucket keys in well under a millisecond.
 
-**Invalidation contract.** An order (and the By-Item key vector) is
-a cache of `(item content, active sort column, buyout state for
-Price/Date)`. Invalidation therefore acts on sorted flags and the
-By-Item keys — never on By-Tab key caches, which don't exist:
+**Invalidation contract.** An order — and every resident key
+vector, By-Tab and By-Item alike (R3-2) — is a cache of
+`(item content, active sort column, buyout state for Price/Date)`.
+Invalidation therefore acts on sorted flags **and on whichever key
+vectors are resident**; each cause states its key effect:
 
 1. A delta that changes a bucket's items clears that bucket's sorted
-   flag and discards the stale entries of its resident key vector; a
-   *visible* (D2) bucket re-establishes order as part of the delta's
-   application — still O(delta + bucket). By-Item: the merge itself
+   flag. Key effect: a *visible* (D2) bucket re-establishes order as
+   part of the delta's application — hydrating its vector first if
+   evicted (R3-1) — discarding the replaced source's entries and
+   adding the arrivals' via the merge/sort, still
+   O(delta + bucket); a collapsed bucket's keys stay absent — no
+   build for a bucket nobody sees. By-Item: the merge itself
    maintains order and keys (D4).
 2. Switching the active sort column discards every resident key
    vector and clears every sorted flag; materialized buckets rebuild
@@ -173,17 +208,25 @@ By-Item keys — never on By-Tab key caches, which don't exist:
    whole-collection worst case (By-Item, or everything expanded) is
    ~0.5 s at 1m, user-initiated, once per switch.
 3. Flipping only the direction re-sorts materialized buckets **on
-   their resident keys — no rebuild (R2-3)** — and clears collapsed
-   buckets' flags.
+   their resident keys — hydrating an evicted vector first (R3-1),
+   otherwise no rebuild (R2-3)** — and clears collapsed buckets'
+   flags.
 4. `BuyoutManager` mutations invalidate Price/Date-dependent order.
    The implementation must route every mutation path through a single
    choke point, and the inventory is exhaustive (R1-6): item
    set-and-clear, tab set-and-clear, **migration** (`MigrateItem`,
    `buyoutmanager.cpp:370` — it changes the lookup result; there is
    no tab-level migration, R2-6), and the scoped and final pricing
-   passes. A design-review criterion checks the enumeration.
+   passes. **Key effect (R3-2)**: with Price or Date active, the
+   affected items' entries in every resident key vector — an
+   expanded By-Tab bucket's as much as By-Item's — are rebuilt
+   before the batch's reorder, so a re-sort never runs on stale
+   resident keys; with any other column active, resident keys
+   encode no buyout state and are untouched (cells still repaint —
+   the batching rules below). A design-review criterion checks the
+   enumeration.
 
-**Buyout observability and batching (R1-6).** Three rules make the
+**Buyout observability and batching (R1-6).** Five rules make the
 invalidation observable and bounded:
 
 - **User commands batch at command scope (R2-5)**: a single UI
@@ -196,10 +239,31 @@ invalidation observable and bounded:
   forbidden at every batch boundary, pass or command.
 - **Pricing passes batch**: the scoped per-delta pass and the final
   passes accumulate invalidations and emit **one** batch at pass
-  end — at most one reorder/model update per pass, never one per
-  `Set` (`pricingPassYieldsSingleModelUpdate` pins it; the quadratic
+  end when the pass is outermost (the nesting and snapshot rules
+  below take over when it is not) — at most one reorder/model
+  update per pass, never one per `Set`
+  (`pricingPassYieldsSingleModelUpdate` pins it; the quadratic
   per-`Set` reorder of the flat bucket is the failure this rule
   exists to prevent).
+- **Nested batches coalesce; only the outermost boundary emits
+  (R3-3)**: the two rules above compose, because a command can
+  contain a pass — `OnBuyoutChange` ends by calling
+  `PropagateTabBuyouts` (`ui/mainwindow.cpp:578`), a pricing pass
+  in its own right. A pass or command boundary reached while an
+  enclosing batch is open emits nothing; its invalidations
+  accumulate into the enclosing batch, which emits once at its own
+  end. One user command is therefore one model update even when it
+  triggers propagation.
+- **The snapshot's pricing sequence is one batch (R3-4)**:
+  `OnItemsRefreshed` runs `MigrateBuyouts` → `ApplyAutoTabBuyouts`
+  → `ApplyAutoItemBuyouts` → `PropagateTabBuyouts` back-to-back
+  (`itemsmanager.cpp:152-155`), and nothing observes UI state
+  between them. The sequence **must** run inside one outer
+  model-invalidation batch — a single model update per snapshot,
+  never up to four, each a potential full By-Item reorder.
+  Persistence writes (`BuyoutManager::Save`) are outside batching
+  and unchanged; only model invalidation coalesces
+  (`snapshotPricingSequenceEmitsOneModelBatch`).
 - **Cell repaint is independent of the active sort column**:
   Price/Date *cells* render buyout state unconditionally
   (`PriceColumn::value` reads the manager), so affected visible rows
@@ -249,7 +313,10 @@ model), and the flag-and-order lifecycle is a complete state machine
    comparator, microseconds keyed — imperceptible against the expand
    paint itself. The same rule serves `RestoreViewExpansion`:
    restoring N expanded buckets sorts exactly those whose flags are
-   invalid. Expanding a bucket whose flag is valid does no sort work.
+   invalid. Expanding a bucket whose flag is valid does no sort
+   work — and builds no keys: the bucket is sorted-but-keyless
+   until a key-consuming event hydrates it (D1's hydration rule,
+   R3-1).
 3. **Collapsing evicts the bucket's keys and nothing else** (R1-5,
    R2-3): the sorted order and the flag persist — collapse is a view
    event, not a model event. Arrival order is never reconstructed; a
@@ -275,8 +342,9 @@ model), and the flag-and-order lifecycle is a complete state machine
 6. The By-Item flat bucket is always visible and therefore always
    sorted (D4); lever B deliberately does not apply to it.
 7. Sort-column header clicks and direction flips re-sort
-   **materialized** buckets only (D1 rules 2–3; flips reuse resident
-   keys, switches rebuild) via the existing `layoutChanged` path;
+   **materialized** buckets only (D1 rules 2–3; flips reuse
+   resident keys, hydrating evicted ones first — R3-1 — and
+   switches rebuild) via the existing `layoutChanged` path;
    collapsed buckets' flags clear and their sort defers to
    expansion.
 
@@ -457,8 +525,12 @@ The By-Item view (single flat bucket holding the whole filtered
 result) is the one structure that fights the delta shape, and lever B
 cannot help it. It gets its own contract:
 
-1. The flat bucket is always materialized: keys resident (D1), order
-   maintained.
+1. The flat bucket is always materialized: order maintained, and
+   keys resident **whenever the search is active** — activation
+   supplies them (a dirty search's refilter builds them as part of
+   its sort; a clean search hydrates eagerly at activation,
+   R3-1/D1), so no delta ever meets a keyless flat bucket and the
+   merge budget in rule 2 holds unconditionally.
 2. A delta applies as: remove the source's rows (erase by
    `FetchSourceKey`, contiguous-run `removeRows` batches), then merge
    the arriving filtered items — sort the ≤ 576 arrivals by key,
@@ -534,7 +606,7 @@ honest full rebuild affordable.
 - **Regex micro-optimization as a lever.** Bounded strictly below A
   (the toString/PrettyName floor leaves ~1.5–2.5 s at 1m) and
   unprototyped. Permitted silently as an implementation detail
-  *inside* the key build (D1 rule 3's 0.37 s column-switch rebuild is
+  *inside* the key build (D1 rule 2's 0.37 s column-switch rebuild is
   ~90% multivalue machinery), forbidden as a substitute for keys.
 - **F66 legacy-store rekeying.** The register names M3 "the natural
   opportunity" if the stores are reworked — M3 reworks the model
@@ -642,8 +714,23 @@ Sort-correctness:
 - `residentKeysScopedToActiveSearch` (R2-4) — with several searches
   including multiple By-Item ones, aggregate resident key memory
   never exceeds one search's worth; deactivating a search evicts its
-  keys, and reactivating rebuilds lazily — no eager rebuild, and no
-  refilter when the search is not dirty.
+  keys, and no refilter runs when the search is not dirty.
+  Reactivation rehydrates a clean By-Tab search lazily, per bucket
+  (a dirty one refilters, the sort supplying its keys); a clean
+  By-Item search hydrates eagerly at activation (the R3-1
+  carve-out — the one deliberate exception to lazy).
+- `reexpandedBucketFlipHydratesOnce` (R3-1) — expand (keys built),
+  collapse (keys evicted), re-expand (valid flag: no sort, no key
+  build): a direction flip then hydrates the bucket's keys exactly
+  once and re-sorts correctly; a second flip rebuilds nothing
+  (probe: key-build counter).
+- `byItemActivationDecidesDirtinessFirst` (R3-1) — deactivate a
+  **clean** By-Item search, reactivate: activation hydrates the
+  flat bucket's keys with no refilter, and the first delta merges
+  with a zero key-build count during application, inside the delta
+  budget. Deactivate a **dirty** one, reactivate: exactly one
+  refilter runs and its sort supplies the keys — no separate
+  hydration before or after (probe: one key build total).
 - `staleOrderNeverSurvivesDelta` — a delta replacing a visible
   bucket's items yields fresh keyed order as part of application;
   stale order never persists on a visible bucket (probe: sort
@@ -652,19 +739,37 @@ Sort-correctness:
   switching the active column discards resident keys, clears every
   sorted flag, and re-sorts materialized buckets only; a direction
   flip re-sorts materialized buckets **on their resident keys with
-  no rebuild**; collapsed buckets sort at their next expansion.
+  no rebuild** (an evicted vector hydrates once — R3-1,
+  `reexpandedBucketFlipHydratesOnce`); collapsed buckets sort at
+  their next expansion.
 - `priceKeysFollowBuyoutEdits` — with Price active, a user buyout
-  edit (item and tab level, set and clear, **and migration** —
-  `MigrateItem`, R1-6/R2-6) reorders affected rows at command end;
+  edit (item and tab level, set and clear) reorders affected rows
+  at command end — **in an expanded By-Tab bucket as well as
+  By-Item (R3-2: the bucket's resident key entries rebuild before
+  the reorder; no re-sort on stale keys)**. Migration
+  (`MigrateItem`, R1-6/R2-6) reorders within the snapshot's outer
+  batch, not at a command end — it runs from
+  `ItemsManager::MigrateBuyouts` during snapshot processing
+  (`itemsmanager.cpp:152`), where there is no user command and the
+  required snapshot batch (R3-4) is always the containing batch.
   Date symmetric; with Name active the same edits reorder nothing.
 - `multiSelectionBuyoutEditReordersOnce` (R2-5) — with Price active
   in By-Item, one buyout command over a many-row selection produces
   exactly one reorder / model update at command end (probe:
-  model-update count), never one per selected row.
+  model-update count), never one per selected row — **the command's
+  trailing `PropagateTabBuyouts` call included: the propagation
+  pass's batch nests inside the command batch and emits nothing of
+  its own (R3-3)**.
 - `pricingPassYieldsSingleModelUpdate` (R1-6) — a scoped or final
   pricing pass touching many items produces at most one reorder /
   model update per pass on the active search (probe: model-update
   count), never one per `Set`.
+- `snapshotPricingSequenceEmitsOneModelBatch` (R3-4) — one final
+  snapshot's `MigrateBuyouts` → `ApplyAutoTabBuyouts` →
+  `ApplyAutoItemBuyouts` → `PropagateTabBuyouts` sequence produces
+  at most one reorder / model update on the active search (probe:
+  model-update count), never one per pass; buyout persistence
+  writes still occur.
 - `priceCellsRepaintUnderAnySortColumn` (R1-6) — with Name active, a
   buyout batch emits `dataChanged` for the affected visible
   Price/Date cells and performs no reordering.
@@ -704,6 +809,11 @@ with headroom, misses gate completion the way M2-M2's did):
   collapsed): ≤ 60 ms at 100k, ≤ 500 ms at 1m end-to-end
   (filter-loop-bound; the sort share ≤ 5 ms).
 - Single-bucket expand (cold keys): ≤ 10 ms at both scales.
+- Clean By-Item search reactivation (eager key hydration, R3-1):
+  ≤ 100 ms at 100k, ≤ 0.5 s at 1m — the cold-reactivation
+  boundary; the By-Item delta budget below then holds
+  unconditionally, no By-Item delta ever paying a flat-bucket key
+  build.
 - By-Item full refilter: ≤ 250 ms at 100k, ≤ 1.5 s at 1m.
 - Broad-filter default-expanded refilter (a filter matching ~all
   items, every bucket visible — R1-8's worst case): ≤ 150 ms at
@@ -729,9 +839,11 @@ Design-review criteria (checked in review, not runnable):
   source of ordering truth; no code path defines order twice.
 - D1 rule 4's `BuyoutManager` mutation enumeration is complete —
   every mutation path, **migration included** (R1-6), flows through
-  the single choke point — and the batching rules hold: pricing
-  passes emit one batch, user edits apply immediately, cell repaint
-  is independent of the active sort column.
+  the single choke point — and the batching rules hold: passes and
+  commands emit one batch at their own end, nested boundaries emit
+  only at the outermost (R3-3), the snapshot's pricing sequence
+  emits one batch (R3-4), and cell repaint is independent of the
+  active sort column.
 - M2's intersection and background-search machinery is inherited
   with exactly two stated renegotiations, neither silent: the
   metadata half added to the intersection contract (R1-4, retiring
@@ -783,9 +895,9 @@ Design-review criteria (checked in review, not runnable):
 | Hold point (Tom, July 30, 2026): levers A+B committed; intended order; memory measured pre-freeze | D1, D2, D5; spike section 4 |
 | M2 hard constraint: no per-delta uncoalesced model reset; freshness bound | D3 (no reset at all; throttle retired, bound trivially met) |
 
-Every named input is consumed. Review rounds 1–2 (R1-1…R1-8,
-R2-1…R2-6, July 30, 2026, all fourteen accepted) are incorporated
-throughout — verdicts and resolutions in
+Every named input is consumed. Review rounds 1–3 (R1-1…R1-8,
+R2-1…R2-6, R3-1…R3-4, July 30, 2026, all eighteen accepted) are
+incorporated throughout — verdicts and resolutions in
 `items-pipeline-m3-reviews.md`, which also carries the revision
 log. The rounds' structural theme: revision 1 specified the
 single-event grain; round 1 forced the sequence grain (source vs.
@@ -794,4 +906,8 @@ rows, pricing-pass batching); round 2 closed the boundaries round
 1's own resolutions opened (intent lifetime at the failure
 terminal, merge order in multi-source buckets, residency across
 searches) and returned one of them — key residency — to the hold
-point's settled cached-key choice (R2-3).
+point's settled cached-key choice (R2-3); round 3 reconciled that
+restoration's consequences — residency as an explicit axis with a
+single hydration rule (R3-1), invalidation over every resident
+cache (R3-2), and the batch boundaries nested (R3-3) and pinned to
+their true call sites (R3-4).

--- a/docs/design/items-pipeline-m3.md
+++ b/docs/design/items-pipeline-m3.md
@@ -1,14 +1,18 @@
 # Items Pipeline Milestone 3: Delta-Native Items Model
 
-Status: **DRAFT, revision 2** (July 30, 2026). In review, not
+Status: **DRAFT, revision 3** (July 30, 2026). In review, not
 frozen; production implementation must not begin against this
-document. Review round 1 (external, eight findings R1-1…R1-8, all
-verified and accepted; none challenging the hold-point decisions) is
-incorporated throughout — the largest changes are D3's source-scoped
-replacement grain (R1-1), the final snapshot's row reconciliation
-(R1-2), the selection-intent contract (R1-3), the metadata half of
-the intersection contract (R1-4), and D1/D2's transient-key state
-machine (R1-5). Unlike M2, the pre-spec evidence is already in hand: the
+document. Review rounds 1–2 (external; R1-1…R1-8 and R2-1…R2-6, all
+fourteen verified and accepted) are incorporated throughout. Round
+1's largest changes: D3's source-scoped replacement grain (R1-1),
+the final snapshot's row reconciliation (R1-2), the selection-intent
+contract (R1-3), the metadata half of the intersection contract
+(R1-4). Round 2 closed the boundaries round 1 opened — the intent
+window now ends at every terminal outcome (R2-1), multi-source
+buckets merge rather than merely sort arrivals (R2-2), and **key
+residency was restored to the hold point's cached-key choice**
+after round 1's transient-key resolution overstepped it (R2-3, with
+residency scoped to the active search per R2-4). Unlike M2, the pre-spec evidence is already in hand: the
 parent plan's "profile before choosing levers" obligation was
 discharged by the S1-M3 sort-profiling spike (July 30, 2026, branch
 `spike/m3-sort-profile`, evidence in `m3-sort-profile-result.md`
@@ -129,18 +133,29 @@ and the suffix's first element) share one buffer; `uid` and `hash`
 are CoW copies of the `Item`'s own members and cost nothing while the
 item lives. Both facts are measured (spike section 4).
 
-**Residency: By-Tab keys are transient, By-Item keys are resident
-(R1-5).** By-Tab bucket keys are sorting scratch: built when the
-bucket sorts, discarded when that sort completes. What persists is
-the bucket's item *order* plus a per-bucket sorted-validity flag
-(D2); no structure above bucket grain ever holds By-Tab keys. The
-By-Item flat bucket alone keeps its key vector resident while that
-view is active — D4's merge probes need it. Build cost is O(bucket)
-— measured 33 ms per 100k items, 368 ms per 1m, so a 576-item bucket
-keys in well under a millisecond. Note this is strictly stronger
-than the spike's "cached keys" 40× path for By-Tab: a bucket whose
-sorted flag is valid does not re-sort *at all*; keys are rebuilt
-only when an order must actually be (re)established.
+**Residency: keys are cached for the active search's materialized
+buckets (R2-3, R2-4 — the hold point's cached-key choice, with its
+lifecycle specified).** A *materialized* bucket is an expanded
+By-Tab bucket or the By-Item flat bucket. The rules:
+
+- Within the **active search**, a materialized bucket keeps its key
+  vector resident from its first sort until evicted — re-sorts and
+  direction flips reuse it without rebuilding (the spike's 40×
+  cached path), and a bucket whose sorted flag is valid skips
+  sorting entirely (D2's flags — stronger still).
+- **Collapse evicts the bucket's keys; its order and sorted flag
+  persist.** This is safe against later Price/Date staleness because
+  invalidation acts on flags independently of key residency — the
+  question R1-5 raised, now answered *within* the cached design.
+- **Residency is scoped to the active search (R2-4).** Deactivating
+  a search evicts every one of its key vectors (orders and flags
+  persist); reactivation rebuilds **lazily**, at the next event that
+  actually needs keys (an invalidated sort, a merge), never eagerly.
+  At most one search holds resident keys at any time — N background
+  By-Item searches hold none, not ~250 MB each.
+- Build cost is O(bucket) — measured 33 ms per 100k items, 368 ms
+  per 1m, so a 576-item bucket keys in well under a millisecond, and
+  a lazy rebuild after reactivation costs only what it re-sorts.
 
 **Invalidation contract.** An order (and the By-Item key vector) is
 a cache of `(item content, active sort column, buyout state for
@@ -148,31 +163,37 @@ Price/Date)`. Invalidation therefore acts on sorted flags and the
 By-Item keys — never on By-Tab key caches, which don't exist:
 
 1. A delta that changes a bucket's items clears that bucket's sorted
-   flag; a *visible* (D2) bucket re-establishes order as part of the
-   delta's application — still O(delta + bucket). By-Item: the merge
-   itself maintains order and keys (D4).
-2. Switching the active sort column clears every sorted flag and
-   discards the By-Item key vector; visible buckets re-sort (each a
-   transient build + sort), collapsed ones simply stay flagged
-   unsorted. The whole-collection worst case (By-Item, or everything
-   expanded) is ~0.5 s at 1m, user-initiated, once per switch.
-3. Flipping only the direction re-sorts visible buckets with the
-   flipped comparison (By-Tab rebuilds transient keys — bucket-grain,
-   trivially cheap; By-Item re-sorts on its resident keys) and clears
-   collapsed buckets' flags.
+   flag and discards the stale entries of its resident key vector; a
+   *visible* (D2) bucket re-establishes order as part of the delta's
+   application — still O(delta + bucket). By-Item: the merge itself
+   maintains order and keys (D4).
+2. Switching the active sort column discards every resident key
+   vector and clears every sorted flag; materialized buckets rebuild
+   and re-sort, collapsed ones simply stay flagged unsorted. The
+   whole-collection worst case (By-Item, or everything expanded) is
+   ~0.5 s at 1m, user-initiated, once per switch.
+3. Flipping only the direction re-sorts materialized buckets **on
+   their resident keys — no rebuild (R2-3)** — and clears collapsed
+   buckets' flags.
 4. `BuyoutManager` mutations invalidate Price/Date-dependent order.
    The implementation must route every mutation path through a single
    choke point, and the inventory is exhaustive (R1-6): item
-   set-and-clear, tab set-and-clear, **migration**
-   (`MigrateItem`/`MigrateTab`, `buyoutmanager.cpp:369` — it changes
-   the lookup result), and the scoped and final pricing passes. A
-   design-review criterion checks the enumeration.
+   set-and-clear, tab set-and-clear, **migration** (`MigrateItem`,
+   `buyoutmanager.cpp:370` — it changes the lookup result; there is
+   no tab-level migration, R2-6), and the scoped and final pricing
+   passes. A design-review criterion checks the enumeration.
 
 **Buyout observability and batching (R1-6).** Three rules make the
 invalidation observable and bounded:
 
-- **User edits apply immediately**: with Price or Date active, an
-  edit reorders the affected visible scope now.
+- **User commands batch at command scope (R2-5)**: a single UI
+  command can loop over every selected row and then trigger
+  propagation (`OnBuyoutChange`, `ui/mainwindow.cpp:541-567` —
+  `SetTab`/`Set` per selected row), so "immediate" means **one batch
+  at command end** — with Price or Date active, one reorder of the
+  affected visible scope per command, never per `Set`
+  (`multiSelectionBuyoutEditReordersOnce`). Per-`Set` reordering is
+  forbidden at every batch boundary, pass or command.
 - **Pricing passes batch**: the scoped per-delta pass and the final
   passes accumulate invalidations and emit **one** batch at pass
   end — at most one reorder/model update per pass, never one per
@@ -186,13 +207,16 @@ invalidation observable and bounded:
   sorts the view; only *reordering* is gated on the active column
   (`priceCellsRepaintUnderAnySortColumn`).
 
-**Memory.** Measured (spike section 4): ~286 B/item accounted for the
-string-heavy worst case. Under the residency rule, resident key
-memory is the By-Item flat bucket **only**: ~266 MB naive at 1m,
-~222 MB with the required `s2`/suffix sharing (D4 accepts this; the
-budget is pinned in the acceptance criteria). By-Tab's transient
-peak is a single bucket — ~0.2 MB at the 576-item cap — regardless
-of collection size or how many buckets are expanded.
+**Memory.** Measured (spike section 4): ~286 B/item accounted for
+the string-heavy worst case. Under the residency rules, resident key
+memory is proportional to the **active search's materialized set**
+and nothing else: the collapsed-default unfiltered view holds ≈ 0;
+background searches hold exactly 0 (R2-4). The worst case is a
+materialized whole-collection result — the By-Item flat bucket, or a
+broad-filter fully-expanded By-Tab result (R2-3) — at ~266 MB naive
+/ ~222 MB with the required `s2`/suffix sharing at 1m. Accepted and
+budgeted (≤ 300 MB aggregate, acceptance criteria); the user paying
+it is holding a million-item sorted view either way.
 
 Reasons:
 
@@ -219,17 +243,18 @@ model), and the flag-and-order lifecycle is a complete state machine
    or refilter changes the bucket's contents, so persistent indexes
    and model invariants hold.
 2. **Expanding** a bucket whose flag is invalid sorts it first
-   (transient keys, D1), then the expansion proceeds. Cost is bounded
+   (building its keys, which then stay resident — D1), then the
+   expansion proceeds. Cost is bounded
    by the 576-item bucket cap: ~3 ms even with the *current*
    comparator, microseconds keyed — imperceptible against the expand
    paint itself. The same rule serves `RestoreViewExpansion`:
    restoring N expanded buckets sorts exactly those whose flags are
    invalid. Expanding a bucket whose flag is valid does no sort work.
-3. **Collapsing changes nothing** (R1-5): the sorted order and the
-   flag persist — collapse is a view event, not a model event.
-   Arrival order is never reconstructed; a bucket that has sorted
-   once simply stays sorted until invalidated. There are no keys to
-   evict, because By-Tab keys are transient (D1).
+3. **Collapsing evicts the bucket's keys and nothing else** (R1-5,
+   R2-3): the sorted order and the flag persist — collapse is a view
+   event, not a model event. Arrival order is never reconstructed; a
+   bucket that has sorted once simply stays sorted until
+   invalidated.
 4. **Invalidation** (content delta, column switch, direction flip,
    buyout batch — D1's contract) clears flags; whether re-sorting
    happens *now* is decided by visibility: visible buckets (expanded,
@@ -240,16 +265,19 @@ model), and the flag-and-order lifecycle is a complete state machine
    honest worst case is a **broad filter** that matches nearly the
    whole collection while expanding every bucket (R1-8 — `m_filtered`
    is set by any single excluded item, `search.cpp:261-290`): the
-   ceiling is the transient build + sort of ~everything on top of the
-   filter loop, ~0.9 s estimated at 1m, with memory unaffected
-   (transient keys, one bucket at a time). This ceiling is accepted
-   and budgeted in M1-M3 (≤ 1.2 s at 1m); the collapsed-default win
-   applies to the unfiltered case only.
+   ceiling is the key build + sort of ~everything on top of the
+   filter loop, ~0.9 s estimated at 1m, **and the resident key
+   footprint approaches the full-collection measurement (~266 MB
+   naive at 1m) while that result stays materialized (R2-3)** — the
+   same ceiling By-Item already accepts (D1 memory rules). Accepted
+   and budgeted in M1-M3 (≤ 1.2 s, ≤ 300 MB at 1m); the
+   collapsed-default win applies to the unfiltered case only.
 6. The By-Item flat bucket is always visible and therefore always
    sorted (D4); lever B deliberately does not apply to it.
-7. Sort-column header clicks and direction flips re-sort **visible**
-   buckets only (D1 rules 2–3) via the existing `layoutChanged`
-   path; collapsed buckets' flags clear and their sort defers to
+7. Sort-column header clicks and direction flips re-sort
+   **materialized** buckets only (D1 rules 2–3; flips reuse resident
+   keys, switches rebuild) via the existing `layoutChanged` path;
+   collapsed buckets' flags clear and their sort defers to
    expansion.
 
 Reasons:
@@ -261,9 +289,9 @@ Reasons:
 - The hold point weighed B's bounded marginal value post-A (~0.13 s
   of a ~0.55 s filter-bound refilter at 1m) against its bookkeeping
   and committed it anyway, buying the collection-size-independent
-  first paint — and, under R1-5's transient keys, B's flag caching
-  is what lets an already-sorted bucket skip re-sorting entirely,
-  which is stronger than any key cache.
+  first paint — and B's flag caching composes with D1's key cache:
+  a valid flag skips the sort entirely, a resident key vector makes
+  an unavoidable re-sort cheap (R2-3).
 - The lazy machinery extends an existing pattern (`m_sorted` +
   sort-on-activation, `search.cpp:461-466`) one level down, from
   model to bucket, rather than inventing a new one.
@@ -271,15 +299,22 @@ Reasons:
 ### D3. Refresh-driven model changes are bucket-scoped operations; the reset is retired from the refresh path
 
 The delta path stops resetting the model. When a delta intersects the
-current search (the M2 D9 intersection machinery, unchanged), it is
-applied as fine-grained operations scoped to the affected bucket:
+current search (the M2 D9 intersection test — item half inherited
+as-is, metadata half added below, R2-6), it is applied as
+fine-grained operations scoped to the affected bucket:
 
 - **Content replacement** (`TabRefreshed`): a **source-scoped**
   replace within the display bucket (R1-1) — remove exactly the rows
   whose items were fetched from the delta's `FetchSourceKey`, insert
-  the arriving items that pass the active filters, sorted if the
-  bucket is visible (D2), arrival-ordered if collapsed. The
-  distinction matters because the display bucket keys on the stable
+  the arriving items that pass the active filters; arrival-ordered
+  if the bucket is collapsed. **If the bucket is visible, the
+  arrivals are sorted among themselves and then merged into the
+  retained rows' order (R2-2)** — removal as contiguous-run
+  `removeRows` batches, insertion as the merge's contiguous
+  `insertRows` runs, O(runs) model operations and O(bucket) work.
+  Sorting the arrivals alone cannot establish the bucket's global
+  order when sibling sources' rows interleave under the sort; the
+  merge is what does. The source-scoped distinction matters because the display bucket keys on the stable
   `(type, id)` and *aggregates* fetch sources: a Map/Unique child
   shares its parent's bucket with its siblings, and M2 D2's accepted
   mixed-generation behavior requires a child's delta to leave
@@ -376,15 +411,21 @@ delta — and M2 R6-3's cross-tab pin
 (`reselectionSurvivesCrossTabMove`) requires selection to survive
 that. The contract: the selection *intent* is the stable item id,
 held independently of row existence. During an active refresh
-(first delta to final reconciliation), removing the selected item's
+(first delta to the terminal outcome), removing the selected item's
 row keeps the intent alive (the visual selection may lapse); any
 later delta inserting an item with that id — any bucket, any view —
-re-adopts the selection through the global identity index. The
-intent is cleared by the final reconciliation completing without
-the id present, or by the user selecting something else. Outside an
-active refresh, a removal clears selection immediately, as today.
-Pinned by `selectionIntentSurvivesCrossTabMoveAcrossDeltas` — the
-successor of M2's pin under no-reset machinery.
+re-adopts the selection through the global identity index.
+**Every `RefreshFinished` outcome closes the intent window (R2-1)**:
+on success, the final reconciliation clears the intent if the id is
+absent; on failure — which emits no final snapshot (M2 D4) — the
+terminal event itself performs the same absence check against the
+visible result, so a stale intent can never survive one refresh and
+unexpectedly reselect an item in a later one. A user selection wins
+at any time. Outside an active refresh, a removal clears selection
+immediately, as today. Pinned by
+`selectionIntentSurvivesCrossTabMoveAcrossDeltas` — the successor of
+M2's pin under no-reset machinery — and
+`selectionIntentClearsOnTerminalFailure`.
 
 **Where resets remain legitimate**: initial population (nothing to
 preserve) and user-initiated structural changes — filter edits, view-
@@ -404,8 +445,11 @@ Reasons:
   removes a whole class of staleness/starvation reasoning (M2 D9
   spent most of its length on it).
 - Rejecting item-level diffs keeps the operation count per delta at
-  O(1) row-op batches, which is what keeps persistent-index handling
-  tractable (`modelTesterPassesUnderDeltaStorm`).
+  O(runs) row-op batches — O(1) in the common single-source-tab
+  case, the merge's run count for multi-source buckets (R2-2, the
+  same bound D4 states for the flat bucket) — which is what keeps
+  persistent-index handling tractable
+  (`modelTesterPassesUnderDeltaStorm`).
 
 ### D4. The By-Item flat bucket: per-delta sorted merge
 
@@ -523,11 +567,15 @@ Model-level (Qt Test, against the `MainWindow` fixture and a direct
   `FetchSourceKey` within the affected bucket; row accounting,
   filtered membership, and (for a visible bucket) keyed order all
   correct after application (R1-1).
-- `childDeltaPreservesSiblingSourcesInParentBucket` (R1-1) — with a
-  Map/Unique parent bucket holding parent items plus two children's
-  items, one child's delta replaces only that child's rows; the
-  sibling's and parent's rows are untouched (M2 D2's
-  mixed-generation behavior at the model layer).
+- `childDeltaPreservesSiblingSourcesInParentBucket` (R1-1, R2-2) —
+  with an expanded Map/Unique parent bucket holding parent items
+  plus two children's items whose sort keys interleave heavily, one
+  child's delta replaces only that child's rows **and the resulting
+  bucket order is globally sorted** (arrivals merged into the
+  retained rows, not appended or sorted separately); the sibling's
+  and parent's rows and their persistent indexes are untouched
+  outside the merge's moves (M2 D2's mixed-generation behavior at
+  the model layer).
 - `finalReconciliationRemovesDeletedTabs` (R1-2) — a refresh whose
   list reconciliation deleted a tab: no delta removes its bucket;
   the final snapshot's reconciliation removes the bucket and its
@@ -587,23 +635,32 @@ Sort-correctness:
 - `collapsedInvalidBucketResortsOnReexpand` (R1-5) — expand,
   collapse, replace the bucket's contents by delta, re-expand: the
   bucket re-sorts exactly once, correctly.
-- `byTabKeysAreTransient` (R1-5) — after any By-Tab sort completes,
-  no key storage remains (probe: live key-vector count returns to
-  zero); only the By-Item flat bucket holds resident keys while
-  active.
+- `keyResidencyFollowsMaterialization` (R2-3) — an expanded bucket's
+  keys persist across re-sorts and direction flips (probe: no key
+  rebuild on a flip); collapsing it evicts its keys (probe: live key
+  bytes drop) while its order and flag persist.
+- `residentKeysScopedToActiveSearch` (R2-4) — with several searches
+  including multiple By-Item ones, aggregate resident key memory
+  never exceeds one search's worth; deactivating a search evicts its
+  keys, and reactivating rebuilds lazily — no eager rebuild, and no
+  refilter when the search is not dirty.
 - `staleOrderNeverSurvivesDelta` — a delta replacing a visible
   bucket's items yields fresh keyed order as part of application;
   stale order never persists on a visible bucket (probe: sort
   counted for that bucket alone).
-- `sortColumnSwitchResortsVisibleBucketsOnly` (R1-5) — switching the
-  active column clears every sorted flag but re-sorts visible
-  buckets only; a direction flip likewise; collapsed buckets sort at
-  their next expansion.
+- `sortColumnSwitchResortsVisibleBucketsOnly` (R1-5, R2-3) —
+  switching the active column discards resident keys, clears every
+  sorted flag, and re-sorts materialized buckets only; a direction
+  flip re-sorts materialized buckets **on their resident keys with
+  no rebuild**; collapsed buckets sort at their next expansion.
 - `priceKeysFollowBuyoutEdits` — with Price active, a user buyout
   edit (item and tab level, set and clear, **and migration** —
-  `MigrateItem`/`MigrateTab`, R1-6) reorders affected rows
-  immediately; Date symmetric; with Name active the same edits
-  reorder nothing.
+  `MigrateItem`, R1-6/R2-6) reorders affected rows at command end;
+  Date symmetric; with Name active the same edits reorder nothing.
+- `multiSelectionBuyoutEditReordersOnce` (R2-5) — with Price active
+  in By-Item, one buyout command over a many-row selection produces
+  exactly one reorder / model update at command end (probe:
+  model-update count), never one per selected row.
 - `pricingPassYieldsSingleModelUpdate` (R1-6) — a scoped or final
   pricing pass touching many items produces at most one reorder /
   model update per pass on the active search (probe: model-update
@@ -634,6 +691,10 @@ Selection intent (R1-3):
   `reselectionSurvivesCrossTabMove`'s successor). If the refresh
   ends without the id reappearing, the final reconciliation clears
   the selection; a user selection made in between wins outright.
+- `selectionIntentClearsOnTerminalFailure` (R2-1) — deltas remove
+  the selected item, then the refresh fails terminally (no final
+  snapshot): the intent is cleared at the terminal event, and a
+  later refresh reinserting the same id does **not** reselect it.
 
 Performance and memory (the M1-M3 checkpoint, Release, recorded
 environment, spike presets; budgets are the spike's measured ceilings
@@ -649,9 +710,11 @@ with headroom, misses gate completion the way M2-M2's did):
   100k, ≤ 1.2 s at 1m.
 - Delta application on the current search, By-Tab visible bucket:
   ≤ 5 ms at 1m; By-Item merge: ≤ 50 ms at 1m.
-- Resident key memory, active column: By-Item at 1m ≤ 300 MB;
-  By-Tab: transient only, single-bucket peak (≤ 1 MB) at any scale
-  and any expansion state (R1-5).
+- Resident key memory, active column, **aggregate across all
+  searches** (R2-4): ≤ 300 MB at 1m in the worst materialized shape
+  (By-Item, or broad-filter fully-expanded By-Tab — R2-3);
+  collapsed-default unfiltered view ≈ 0; background searches
+  exactly 0.
 
 Design-review criteria (checked in review, not runnable):
 
@@ -704,7 +767,7 @@ Design-review criteria (checked in review, not runnable):
 
 | Input (parent plan M3 section, spike, register, hold point) | Consumed by |
 |---|---|
-| Bucket architecture matches the delta shape; tab delta → fine-grained ops or one-bucket replace | D3 (one-bucket replace chosen) |
+| Bucket architecture matches the delta shape; tab delta → fine-grained ops or one-bucket replace | D3 (source-scoped replace within the display bucket, with sorted merge — R1-1/R2-2) |
 | By-Item single flat bucket needs a sorted merge per delta | D4 |
 | Pricing semantics settled by M2 D7; M3 inherits | Scope (out), staleness preamble |
 | Success criterion: refreshing one tab leaves everything else untouched; full refresh = N deltas, no destructive path | D3, `unrelatedDeltaLeavesOtherBucketsUntouched`, `noModelResetDuringRefresh` |
@@ -720,10 +783,15 @@ Design-review criteria (checked in review, not runnable):
 | Hold point (Tom, July 30, 2026): levers A+B committed; intended order; memory measured pre-freeze | D1, D2, D5; spike section 4 |
 | M2 hard constraint: no per-delta uncoalesced model reset; freshness bound | D3 (no reset at all; throttle retired, bound trivially met) |
 
-Every named input is consumed. Review round 1 (R1-1…R1-8, July 30,
-2026, all accepted) is incorporated throughout — verdicts and
-resolutions in `items-pipeline-m3-reviews.md`, which also carries
-the revision log. The round's structural theme: revision 1
-specified the single-event grain and round 1 forced the sequence
-grain (source vs. display bucket, cross-delta selection state,
-snapshot-boundary rows, pricing-pass batching).
+Every named input is consumed. Review rounds 1–2 (R1-1…R1-8,
+R2-1…R2-6, July 30, 2026, all fourteen accepted) are incorporated
+throughout — verdicts and resolutions in
+`items-pipeline-m3-reviews.md`, which also carries the revision
+log. The rounds' structural theme: revision 1 specified the
+single-event grain; round 1 forced the sequence grain (source vs.
+display bucket, cross-delta selection state, snapshot-boundary
+rows, pricing-pass batching); round 2 closed the boundaries round
+1's own resolutions opened (intent lifetime at the failure
+terminal, merge order in multi-source buckets, residency across
+searches) and returned one of them — key residency — to the hold
+point's settled cached-key choice (R2-3).

--- a/docs/design/items-pipeline-m3.md
+++ b/docs/design/items-pipeline-m3.md
@@ -1,0 +1,533 @@
+# Items Pipeline Milestone 3: Delta-Native Items Model
+
+Status: **DRAFT, revision 1** (July 30, 2026). Not reviewed, not
+frozen; production implementation must not begin against this
+document. Unlike M2, the pre-spec evidence is already in hand: the
+parent plan's "profile before choosing levers" obligation was
+discharged by the S1-M3 sort-profiling spike (July 30, 2026, branch
+`spike/m3-sort-profile`, evidence in `m3-sort-profile-result.md`
+beside this spec), and the lever hold point ran the same day. **At
+that hold point Tom selected: levers A and B both committed (D1, D2),
+the intended `(name, uid, hash)` tie-break order (D5, fixing F67 as a
+side effect), and the key-memory measurement run pre-freeze rather
+than deferred** — it ran the same day as a spike extension (~286
+B/item accounted; ~266 MB naive at 1m; section 4 of the spike
+result). This spec consumes the M3 inbox in `items-pipeline.md`
+("Inputs accumulated for the M3 spec") and the spike's evidence; the
+traceability table at the end maps every input to the decision,
+deferral, or acceptance criterion that consumed it.
+
+Citation convention: bare D-numbers (D1, D2, …) in this document are
+this document's decisions; M2's decisions are cited qualified ("M2
+D9"), as are the network redesign's. F-numbers are the findings
+register (`docs/cleanup/findings.md`); `R1-*` (and later `R2-*`, …)
+are this spec's review-round findings, recorded with verdicts and
+resolutions in `items-pipeline-m3-reviews.md` from round 1; pinned
+test names are quoted in `camelCase`. "The spike" unqualified means
+S1-M3.
+
+## Staleness preamble
+
+Written against commit `3549b214` (master, July 30, 2026 — the M2
+merge, PR #185). The load-bearing code assumptions; re-verify these
+anchors before implementing against any section, and re-verify the
+whole list if the model layer or the delta path has been touched
+since:
+
+- **Delta application (M2 D9)**: `MainWindow::OnTabRefreshed` /
+  `OnChildrenReconciled` (`ui/mainwindow.cpp:709-736`) mark every
+  search items-dirty (rule 1), intersection-gate against the current
+  search, and call `ScheduleThrottledRefilter()`
+  (`ui/mainwindow.cpp:756`) — a non-resetting trailing throttle with
+  period S = 60 s (`m_delta_throttle`). `OnDeltaThrottleTimeout` →
+  `ModelViewRefresh` (`ui/mainwindow.cpp:828`), which captures
+  expansion and scroll, refilters, resets the model, and restores
+  (`RestoreViewExpansion`, `ReselectCurrentItem`, the scroll anchor).
+- **The reset**: `ItemsModel::beginUpdate()` is literally
+  `beginResetModel()` (`items_model.h:28`). One sort column and order
+  per model (`m_sort_column`/`m_sort_order`; the pinned default is
+  column 0 = Name, descending) with a lazy `m_sorted` flag:
+  `Search::FilterItems` ends with `SetSorted(false)` and the sort
+  actually runs on activation (`search.cpp:461-466`) via
+  `ItemsModel::sort` → `Search::Sort` (`search.cpp:201`) →
+  `Bucket::Sort` (`bucket.cpp:41`), a per-bucket `std::sort` calling
+  `Column::lt` per comparison.
+- **Comparator surface**: 26 columns (`search.cpp:33-59`), three
+  comparator implementations — the `Column::lt`/`Column::multivalue`
+  base (`column.cpp:28-67`; two static `QRegularExpression`s, string
+  fallback path), and the `PriceColumn::lt`/`DateColumn::lt`
+  overrides, which read `BuyoutManager` per comparison. Ties fall
+  through to `Item::operator<` (`item.cpp`), whose hash term is dead
+  code (F67).
+- **Search state rebuilt by every refilter** (`search.h`):
+  `m_bucket_by_tab`/`m_bucket_by_item` (`ViewMode::ByTab`/`ByItem`),
+  expansion keyed by stable `(type, id)` (M2 R6-3,
+  `m_expanded_keys`), the reselection index `m_visible_by_id`, the
+  intersection sets `m_visible_sources`(`_by_tab`), and the scroll
+  anchor. `defaultExpanded()` is `m_filtered || ByItem`
+  (`search.h:86`). Buckets hold `std::shared_ptr<Item>` vectors;
+  per-tab caps bound a display bucket at 576 items (quad tab).
+- **The M2 signal surface is settled ground**: worker
+  `TabRefreshed(location, items)` and
+  `ChildrenReconciled(parent, expected)` deltas, the typed
+  `RefreshFinished` terminal, the unchanged final `ItemsRefreshed`
+  snapshot (M2 D8), scoped per-delta pricing in `ItemsManager` (M2
+  D7), and `SourceKeyedItems` on both worker and manager (the M2-M2
+  remedy pair). M3 changes none of it; this spec touches only Layer 3
+  (search/model/view).
+- **Initial cached load**: the parse thread publishes one snapshot
+  (`ItemsRefreshed(..., true)`); the first population of a search's
+  model has no view state to preserve.
+
+## Scope
+
+M3 makes Layer 3 consume deltas natively and retires the two costs
+the evidence localized: the destructive whole-model reset on the
+refresh path, and the comparator-bound re-sort. Concretely: a tab
+delta becomes bucket-scoped model operations instead of a throttled
+reset (D3); sorting runs on precomputed cached keys (D1, hold-point
+lever A) and only for buckets whose order is visible (D2, hold-point
+lever B); the By-Item flat bucket gets a per-delta sorted merge (D4);
+the tie-break becomes the intended `(name, uid, hash)` order, fixing
+F67 (D5). The user-initiated full refilter survives as a
+non-refresh-driven path and gets cheap by the same levers (D6).
+
+Out of scope, each with reasons: the filter loop, born-sorted
+masters, regex micro-optimization as a lever, F66's legacy-store
+rekeying, key persistence (D7); pricing semantics (settled, M2 D7 —
+M3's concern is model operations, not pricing).
+
+## Decisions
+
+### D1. The central lever: precomputed, cached sort keys (hold point, lever A)
+
+Sorting never calls `Column::lt` per comparison. Each materialized
+bucket (D2) carries a key vector parallel to its items; `Bucket::Sort`
+orders `(key, item)` pairs with plain tuple comparison and the bucket
+adopts the resulting item order.
+
+**Key shape.** The key is the comparator's own tuple, materialized
+once per item — the comparator remains the single source of ordering
+truth, and keys are derived from it, never a second definition:
+
+- Base columns: the `multivalue` tuple `(d1, s1, d2, s2)` exactly as
+  `Column::multivalue` computes it (`column.cpp:28-61`), plus the
+  tie-break suffix.
+- `PriceColumn`: `(currency rank, value)` plus the suffix.
+- `DateColumn`: `(last_update)` plus the suffix.
+- The tie-break suffix is `(PrettyName, uid, hash)` — the intended
+  order per D5.
+
+The two identical `PrettyName` strings on the base string path (`s2`
+and the suffix's first element) share one buffer; `uid` and `hash`
+are CoW copies of the `Item`'s own members and cost nothing while the
+item lives. Both facts are measured (spike section 4).
+
+**Lifetime and invalidation contract.** Keys are a cache of
+`(item content, active sort column, buyout state for Price/Date)`:
+
+1. Keys are built lazily, per bucket, the first time that bucket
+   sorts (composing with D2: collapsed buckets hold no keys). Build
+   cost is O(bucket) — measured 33 ms per 100k items, 368 ms per 1m,
+   so a 576-item bucket keys in well under a millisecond.
+2. A delta that replaces a bucket's items discards that bucket's
+   keys; they rebuild at the bucket's next sort (for a materialized
+   bucket, immediately — still O(delta)).
+3. Switching the active sort column discards all key vectors
+   (order-only changes — ascending/descending — do not; the
+   comparison flips, the keys stand). The rebuild is user-initiated
+   and O(materialized set); the whole-collection worst case is
+   ~0.37 s at 1m, paid once per column switch.
+4. When and only when the active column is Price or Date, every
+   `BuyoutManager` mutation path (item set/clear, tab set/clear, the
+   scoped and final pricing passes) marks dependent buckets'
+   key vectors stale. The implementation must enumerate these paths
+   at a single choke point; a design-review criterion checks the
+   enumeration, and `priceKeysFollowBuyoutEdits` pins the observable
+   behavior. Other columns' keys are indifferent to buyout state by
+   construction.
+
+**Memory.** Measured (spike section 4): ~286 B/item accounted for the
+string-heavy worst case. Under D2's lazy per-bucket build the
+resident set is proportional to the materialized set — a collapsed
+default view holds approximately no keys. The documented worst case
+is the By-Item flat bucket at 1m with a base column active: ~266 MB
+naive, ~222 MB with the required `s2`/suffix sharing (D4 accepts
+this; the budget is pinned in the acceptance criteria).
+
+Reasons:
+
+- The spike proved the sort comparator-bound and the comparator
+  regex-bound (~3/4 of every call); keys retire the whole per-
+  comparison toll: 40× on cached keys, 10× even rebuilding every
+  refilter, and `std::sort` machinery is ~12–13 ns/compare.
+- Keys are the only measured lever that helps every structure,
+  including the By-Item flat bucket (12.9 s → ~0.77 s at 1m even
+  rebuilding; D4 does better by merging).
+- The cache contract fits the delta shape: deltas arrive per fetch
+  source, buckets key per display tab, so invalidation is naturally
+  bucket-scoped and O(delta).
+
+### D2. Deferred sorting: only visible order is paid for (hold point, lever B)
+
+A bucket's item order is established only when that order can be
+seen. Each bucket carries a sorted flag (per search, per model):
+
+1. A **collapsed** By-Tab bucket is never sorted; it keeps arrival
+   order. Unsorted is not unstable: the order is deterministic until
+   a delta or refilter changes the bucket's contents, so persistent
+   indexes and model invariants hold.
+2. Expanding a bucket sorts it first (building its keys per D1 if
+   absent), then the expansion proceeds. Cost is bounded by the
+   576-item bucket cap: ~3 ms even with the *current* comparator,
+   microseconds keyed — imperceptible against the expand paint
+   itself. The same rule serves `RestoreViewExpansion`: restoring N
+   expanded buckets sorts exactly those N.
+3. Filtered searches are default-expanded (`search.h:86`), so every
+   visible bucket of a filtered result sorts eagerly — acceptable
+   because a filtered result is small by construction; the expensive
+   case (whole collection, unfiltered) is exactly the case that
+   starts fully collapsed.
+4. The By-Item flat bucket is always visible and therefore always
+   sorted (D4); lever B deliberately does not apply to it.
+5. Sort-column header clicks re-sort **materialized** buckets only
+   (per D1 rule 3) via the existing `layoutChanged` path; collapsed
+   buckets simply drop their sorted flag.
+
+Reasons:
+
+- Measured: sorting only the expanded set costs 15–63 ms independent
+  of collection size, and the default unfiltered view starts fully
+  collapsed — the whole-model sort at first paint disappears rather
+  than being merely cheapened.
+- The hold point weighed B's bounded marginal value post-A (~0.13 s
+  of a ~0.55 s filter-bound refilter at 1m) against its bookkeeping
+  and committed it anyway, buying the collection-size-independent
+  first paint and the lazy key memory profile (D1) — B is what makes
+  "approximately no keys resident by default" true.
+- The lazy machinery extends an existing pattern (`m_sorted` +
+  sort-on-activation, `search.cpp:461-466`) one level down, from
+  model to bucket, rather than inventing a new one.
+
+### D3. Refresh-driven model changes are bucket-scoped operations; the reset is retired from the refresh path
+
+The delta path stops resetting the model. When a delta intersects the
+current search (the M2 D9 intersection machinery, unchanged), it is
+applied as fine-grained operations scoped to the affected bucket:
+
+- **Content replacement** (`TabRefreshed`): one bucket-scoped
+  replace — remove that bucket's filtered rows, insert the arriving
+  items that pass the active filters, sorted if the bucket is
+  materialized (D2), arrival-ordered if collapsed. Item-level
+  diffing is deliberately rejected: M2 D2/D3 define the delta as a
+  whole-fetch-source replacement, so a one-bucket replace is the
+  delta's native grain.
+- **Child reconciliation** (`ChildrenReconciled`): the erase becomes
+  row removals scoped to the parent's bucket.
+- **New tab discovered**: the bucket row is inserted at its display
+  position (`begin/endInsertRows` at top level). **Deletion stays a
+  snapshot-boundary effect** (M2 D6): an empty delta empties a
+  bucket, it never removes one.
+- **Metadata changes** (rename, move, color): the bucket row updates
+  in place (`dataChanged`) and repositions with `beginMoveRows` when
+  display ordering changes; expansion and selection follow the
+  stable `(type, id)` key exactly as in M2 R6-3 — the machinery the
+  parent plan carries forward as M3's bucket keying.
+- **Search-side indexes are maintained incrementally**: the delta
+  updates `m_visible_by_id`, `m_visible_sources`(`_by_tab`), and the
+  bucket in O(delta); no whole-collection rebuild rides along. The
+  full rebuild remains the refilter's job (D6).
+
+**The D9 throttle is retired for the current search.** Its reason to
+exist — reset-plus-restore too expensive to pay per delta — is gone:
+a bucket-scoped application is O(delta) work (filter the arriving
+items with `MatchesActiveFilters`, keyed sort of ≤ 576 items, row
+ops). Deltas apply as they arrive; the freshness bound M2 D9 stated
+becomes trivially "immediate", and M2's hard constraint ("no
+per-delta uncoalesced model reset") is honored by having no reset at
+all. Rule 1 (every delta marks every search items-dirty) and
+dirty-on-activation for background searches are unchanged.
+
+**The final snapshot stops being a destructive event for the open
+window.** On `ItemsRefreshed` after a refresh, the current search —
+already delta-fresh — performs one non-destructive reconciliation:
+bucket metadata refresh against the rebased locations
+(`RebaseItemLocations` runs at the success terminal, a
+snapshot-boundary effect per M2 D6) and bucket reordering via move
+ops. No `beginResetModel`. Background searches keep the existing
+flag-and-refilter-on-activation path. A full refresh with the window
+open is then, as the parent plan requires, just N deltas plus one
+cheap reconciliation — no special destructive path left.
+
+**Where resets remain legitimate**: initial population (nothing to
+preserve) and user-initiated structural changes — filter edits, view-
+mode switches, search switches — where the R6-3 capture/restore
+machinery already covers fidelity (D6). Never on the refresh path;
+`noModelResetDuringRefresh` pins this.
+
+Reasons:
+
+- The spike killed the alternative framing: begin/endResetModel are
+  microseconds, so the reset was never the cost — but the *restore*
+  obligations it creates (recapture, refilter, re-sort, reselect) are
+  the whole cascade. Scoped ops make the untouched state simply never
+  move, which is the milestone's success criterion.
+- Per-delta cost is bounded and small (O(delta) + a ≤ 576-item keyed
+  sort), so no coalescing layer is needed; deleting the throttle
+  removes a whole class of staleness/starvation reasoning (M2 D9
+  spent most of its length on it).
+- Rejecting item-level diffs keeps the operation count per delta at
+  O(1) row-op batches, which is what keeps persistent-index handling
+  tractable (`modelTesterPassesUnderDeltaStorm`).
+
+### D4. The By-Item flat bucket: per-delta sorted merge
+
+The By-Item view (single flat bucket holding the whole filtered
+result) is the one structure that fights the delta shape, and lever B
+cannot help it. It gets its own contract:
+
+1. The flat bucket is always materialized: keys resident (D1), order
+   maintained.
+2. A delta applies as: remove the source's rows (erase by
+   `FetchSourceKey`, contiguous-run `removeRows` batches), then merge
+   the arriving filtered items — sort the ≤ 576 arrivals by key,
+   then a single merge pass against the resident order, inserted as
+   contiguous-run `insertRows` batches. Work is O(n + d) per delta
+   (the vector shuffle dominates; at 1m that is tens of
+   milliseconds), model ops are O(runs), and the result must equal a
+   full keyed re-sort (`byItemMergeMatchesFullSort`).
+3. The memory worst case is accepted and documented: ~222–266 MB
+   resident keys at 1m on a base column (D1). The user paying it
+   today pays 12.9 s per refilter for the same view; the trade is
+   deliberate. The budget is pinned (≤ 300 MB at 1m, acceptance
+   criteria).
+4. A full By-Item refilter (user-initiated) is the keyed build + flat
+   sort: measured ~0.77 s at 1m against 12.9 s today.
+
+Reason: the parent plan names this structure explicitly ("the one
+structure that fights the delta shape") and the spike quantified both
+the threat (12.9 s, immune to lever B) and the remedy's ceiling. An
+O(n) merge pass per delta is the honest cost of a single sorted
+container; pretending a flat bucket can take O(d) updates would be
+designing against arithmetic.
+
+### D5. The tie-break becomes the intended `(name, uid, hash)` order (hold point; fixes F67)
+
+`Item::operator<`'s third tuple element becomes `rhs.m_hash` (the
+one-token F67 fix), restoring the intended hash-level determinism for
+id-less items, and D1's key suffix carries the hash so keyed and
+comparator order agree everywhere —
+`keyedOrderMatchesComparatorOrder` is the equivalence pin and
+`intendedTieBreakRestored` the determinism pin. The only visible
+change is that items with no server id that tie on name now order
+deterministically instead of arbitrarily. F67's register entry is
+moved to the resolved ledger when this lands.
+
+Reason: the hold point chose intended over actual order — determinism
+for the price of one CoW QString per key (measured free while the
+item lives), versus preserving an ordering accident nobody depends
+on.
+
+### D6. The user-initiated refilter: kept, and cheap by the same levers
+
+Filter edits, view-mode switches, and search switches keep today's
+shape — capture, `FilterItems`, reset, restore (R6-3 machinery
+unchanged) — because a changed filter genuinely invalidates the whole
+derived view. What changes is the price: the post-reset sort
+disappears into D1/D2 (collapsed buckets sort nothing; restored
+expansions sort their N buckets keyed; By-Item pays the keyed flat
+sort). The refilter's residual cost is then the filter loop itself —
+~34 ms at 100k, ~391 ms at 1m, now the dominant term. **Optimizing
+the filter loop is explicitly out of scope** (D7) but the fact is
+recorded: post-M3, "refilter cost" means "filter-loop cost".
+
+Reason: the refresh path (D3) and the user-refilter path have
+different invalidation semantics — a delta invalidates one bucket, a
+filter edit invalidates everything — and forcing them through one
+mechanism would either reintroduce whole-view work per delta or
+incremental-filter complexity M3 does not need. The levers make the
+honest full rebuild affordable.
+
+### D7. Deferrals, each with its reason
+
+- **Filter-loop optimization.** Post-M3 the dominant refilter term
+  (~0.4 s at 1m). Deferred: it is orthogonal to the delta-native
+  model and the sort levers, and it needs its own profile-first pass
+  (per-filter attribution) before choosing a lever. Routed to the
+  parent plan as a follow-up input, not silently dropped.
+- **Born-sorted master buckets.** Never prototyped; its marginal win
+  over cached keys is bounded by the numbers at ~0.13 s per 1m
+  refilter, against pipeline-wide sortedness maintenance and a
+  master-per-sort-order problem. Reopen only if D1's invalidation
+  proves intractable in practice.
+- **Regex micro-optimization as a lever.** Bounded strictly below A
+  (the toString/PrettyName floor leaves ~1.5–2.5 s at 1m) and
+  unprototyped. Permitted silently as an implementation detail
+  *inside* the key build (D1 rule 3's 0.37 s column-switch rebuild is
+  ~90% multivalue machinery), forbidden as a substitute for keys.
+- **F66 legacy-store rekeying.** The register names M3 "the natural
+  opportunity" if the stores are reworked — M3 reworks the model
+  layer, not the legacy persisted stores, so the hook stays parked in
+  the register. Nothing in this spec touches location-keyed
+  persistence.
+- **Key persistence across sessions.** Keys rebuild from live items
+  in well under a second at any realistic scale; persisting a cache
+  of derived strings buys nothing and adds an invalidation surface to
+  the datastore. Rejected, not deferred.
+- **`QueueUpdated` coalescing (M1-M2)** stays a post-M2 follow-up
+  where M2 left it; nothing here changes its standing.
+
+## Acceptance criteria
+
+Model-level (Qt Test, against the `MainWindow` fixture and a direct
+`Search`/`ItemsModel` harness):
+
+- `unrelatedDeltaLeavesOtherBucketsUntouched` — the milestone's
+  success criterion as a test: refresh one tab; every other bucket's
+  expansion, selection, scroll anchor, and persistent indexes are
+  bit-identical, and no restore machinery runs (probe: capture/
+  restore entry counts stay zero).
+- `noModelResetDuringRefresh` — a complete refresh (N deltas, child
+  reconciliations, terminal, final snapshot) with the window open
+  emits zero `begin`/`endResetModel` on the current search's model;
+  the final snapshot performs only the D3 reconciliation
+  (metadata `dataChanged` + `beginMoveRows` repositioning).
+- `deltaReplacesExactlyItsBucketRows` — a content delta's row
+  operations touch exactly the affected bucket; row accounting,
+  filtered membership, and (for a materialized bucket) keyed order
+  all correct after application.
+- `emptyDeltaEmptiesBucketWithoutRemovingIt` — the M2 D6 boundary at
+  the model layer: an empty replacement leaves an empty bucket row
+  (unfiltered search), never a bucket removal.
+- `deltaUpdatesVisibleIndexesIncrementally` — after a delta,
+  `m_visible_by_id`, `m_visible_sources`, and `HasVisibleGhostUnder`
+  answer as if freshly refiltered, with no whole-collection rebuild
+  (probe: rebuild counters).
+- `bucketRepositionsByMoveOnMetadataDelta` — a rename/move delta
+  repositions the bucket via move operations; expansion and selection
+  follow the stable `(type, id)` key (extends M2 R6-3's pins from
+  reset-restore to move).
+- `modelTesterPassesUnderDeltaStorm` — `QAbstractItemModelTester`
+  attached through a randomized storm of deltas (content, empty,
+  reconciliation, metadata, new-tab) interleaved with expansion
+  changes, sort clicks, and view-mode switches.
+
+Sort-correctness:
+
+- `keyedOrderMatchesComparatorOrder` — for every column: the keyed
+  sort of a mixed dataset (double path, range paths, string path,
+  heavy ties, id-less items) is identical to a direct `Column::lt`
+  sort with the D5-fixed comparator, both directions.
+- `intendedTieBreakRestored` — id-less items tying on `PrettyName`
+  order deterministically by hash across repeated sorts and merges
+  (F67 resolved).
+- `collapsedBucketsDeferSorting` — an unfiltered By-Tab refilter
+  sorts no collapsed bucket and builds no keys for one (probe:
+  key-build and compare counters at zero); expanding one bucket sorts
+  exactly that bucket, correctly.
+- `restoredExpansionSortsRestoredBucketsOnly` — a user refilter with
+  N saved expansions sorts exactly those N buckets on restore.
+- `filteredSearchSortsAllVisibleBuckets` — a filtered
+  (default-expanded) search presents every bucket sorted.
+- `keyCacheInvalidatedByDelta` — a delta replacing a materialized
+  bucket's items yields fresh keyed order immediately; stale keys
+  never order fresh items (probe: key rebuild counted for that bucket
+  alone).
+- `sortColumnSwitchRebuildsMaterializedKeysOnly` — switching the
+  active column rebuilds keys for materialized buckets only;
+  flipping only the direction rebuilds none.
+- `priceKeysFollowBuyoutEdits` — with Price active, a user buyout
+  edit (item and tab level, set and clear) reorders affected rows;
+  Date symmetric; with Name active the same edits rebuild nothing.
+
+By-Item:
+
+- `byItemMergeMatchesFullSort` — after any sequence of deltas, the
+  flat bucket's order equals a from-scratch keyed sort of the same
+  filtered collection.
+- `byItemRemovalOnlyDeltaErasesInPlace` — an empty replacement
+  removes exactly the source's rows via row operations; no reset, no
+  full re-sort.
+- `byItemSelectionSurvivesMerge` — a selected item retains selection
+  through a merge that moves its row; a removed item clears it
+  (stable-identity reselection at merge grain).
+
+Performance and memory (the M1-M3 checkpoint, Release, recorded
+environment, spike presets; budgets are the spike's measured ceilings
+with headroom, misses gate completion the way M2-M2's did):
+
+- Worst-case unfiltered By-Tab refilter (user-initiated, default
+  collapsed): ≤ 60 ms at 100k, ≤ 500 ms at 1m end-to-end
+  (filter-loop-bound; the sort share ≤ 5 ms).
+- Single-bucket expand (cold keys): ≤ 10 ms at both scales.
+- By-Item full refilter: ≤ 250 ms at 100k, ≤ 1.5 s at 1m.
+- Delta application on the current search, By-Tab materialized
+  bucket: ≤ 5 ms at 1m; By-Item merge: ≤ 50 ms at 1m.
+- Resident key memory, active column, By-Item at 1m: ≤ 300 MB;
+  By-Tab default view: proportional to the materialized set
+  (≈ 0 collapsed).
+
+Design-review criteria (checked in review, not runnable):
+
+- No refresh-driven path reaches `beginResetModel`; resets exist only
+  on initial population and user-initiated structural changes (D3's
+  enumerated list).
+- The delta path is O(delta + affected bucket) everywhere except
+  D4's stated O(n + d) By-Item merge pass; no whole-collection scan
+  or rebuild rides on any delta (M2 hard constraint, extended to the
+  model layer).
+- Keys are derived from the comparators, which remain the single
+  source of ordering truth; no code path defines order twice.
+- D1 rule 4's `BuyoutManager` mutation enumeration is complete —
+  every mutation path flows through the single choke point that
+  marks Price/Date keys stale.
+- M2's intersection, dirty-flag, and background-search machinery is
+  unchanged; the persistence and presentation lanes still share no
+  payload types, and keys carry no wire or `poe::*` types.
+- The retirement of the D9 throttle deletes its machinery and its
+  pinned timer tests by renegotiation, not silent breakage — the M2
+  pins that encode "throttled reset" behavior are explicitly
+  superseded here, each mapped to its D3-era replacement in the
+  implementation plan.
+
+## Open items requiring spike or measurement (not argument)
+
+- **S1-M3 (spike, pre-spec — RESOLVED before this draft):** the
+  sort-profiling spike, run July 30, 2026 on `spike/m3-sort-profile`
+  (never merged; off master `3549b214`). Proved the sort
+  comparator-bound and the comparator regex-bound; quantified levers
+  A (~10–40×), B (proportional to expanded set), and the By-Item
+  worst case; measured the key-memory extension at the hold point
+  (~286 B/item; ~266 MB naive at 1m). Evidence:
+  `m3-sort-profile-result.md`. Consumed by D1–D6 and the hold-point
+  record.
+- **M1-M3 (measurement, implementation checkpoint — blocks M3
+  completion):** the performance/memory budget table above, run on
+  the implemented model with the spike presets and a recorded
+  environment, plus per-component attribution (filter loop, key
+  build, sort, model ops, merge) so a miss names its component
+  before a remedy is chosen — the M2-M2 discipline. Delta-application
+  scenarios use fixed recorded reply shapes as M2-M2's did.
+
+## Input traceability
+
+| Input (parent plan M3 section, spike, register, hold point) | Consumed by |
+|---|---|
+| Bucket architecture matches the delta shape; tab delta → fine-grained ops or one-bucket replace | D3 (one-bucket replace chosen) |
+| By-Item single flat bucket needs a sorted merge per delta | D4 |
+| Pricing semantics settled by M2 D7; M3 inherits | Scope (out), staleness preamble |
+| Success criterion: refreshing one tab leaves everything else untouched; full refresh = N deltas, no destructive path | D3, `unrelatedDeltaLeavesOtherBucketsUntouched`, `noModelResetDuringRefresh` |
+| Inbox: reset cost is the re-sort; user refilter still pays at scale; levers to weigh (keys / expanded-only / born-sorted); profile before choosing | S1-M3 ran (profile obligation); D1, D2 (chosen levers), D7 (born-sorted deferred) |
+| Inbox: R6-3 fidelity machinery negligible; carries forward as M3's bucket keying | D3 (metadata/move rule), D6 (restore path kept) |
+| Spike 1: comparator regex-bound; any lever skipping `multivalue` per comparison captures the win; regex-only variant unprototyped | D1, D7 (regex micro-opt bounded and demoted) |
+| Spike 2: levers compose (cost per comparison × number of comparisons), ceilings 10–40× and proportional-to-expanded | D1 + D2 committed together (hold point) |
+| Spike 3: By-Item flat bucket worst by far, immune to lever B; must be answered | D4 |
+| Spike 4: begin/end reset ~free; filter loop is the next term once sort stops dominating | D3 (reset retired as *path*, not cost), D6, D7 (filter loop routed as follow-up) |
+| Spike section 4: key memory ~286 B/item, ~266 MB naive at 1m; uid/hash CoW free; s2 dedupe saves ~44 MB | D1 (memory rules), D4 rule 3, memory budget |
+| F67: dead hash tie-break; keyed design must choose intended vs actual order | D5 (intended; hold point) |
+| F66: M3 named as natural opportunity if stores reworked | D7 (explicitly not exercised; hook stays) |
+| Hold point (Tom, July 30, 2026): levers A+B committed; intended order; memory measured pre-freeze | D1, D2, D5; spike section 4 |
+| M2 hard constraint: no per-delta uncoalesced model reset; freshness bound | D3 (no reset at all; throttle retired, bound trivially met) |
+
+Every named input is consumed. Review rounds begin at round 1 in
+`items-pipeline-m3-reviews.md`, which also carries the revision log.

--- a/docs/design/items-pipeline-m3.md
+++ b/docs/design/items-pipeline-m3.md
@@ -1,8 +1,14 @@
 # Items Pipeline Milestone 3: Delta-Native Items Model
 
-Status: **DRAFT, revision 1** (July 30, 2026). Not reviewed, not
+Status: **DRAFT, revision 2** (July 30, 2026). In review, not
 frozen; production implementation must not begin against this
-document. Unlike M2, the pre-spec evidence is already in hand: the
+document. Review round 1 (external, eight findings R1-1…R1-8, all
+verified and accepted; none challenging the hold-point decisions) is
+incorporated throughout — the largest changes are D3's source-scoped
+replacement grain (R1-1), the final snapshot's row reconciliation
+(R1-2), the selection-intent contract (R1-3), the metadata half of
+the intersection contract (R1-4), and D1/D2's transient-key state
+machine (R1-5). Unlike M2, the pre-spec evidence is already in hand: the
 parent plan's "profile before choosing levers" obligation was
 discharged by the S1-M3 sort-profiling spike (July 30, 2026, branch
 `spike/m3-sort-profile`, evidence in `m3-sort-profile-result.md`
@@ -101,10 +107,10 @@ M3's concern is model operations, not pricing).
 
 ### D1. The central lever: precomputed, cached sort keys (hold point, lever A)
 
-Sorting never calls `Column::lt` per comparison. Each materialized
-bucket (D2) carries a key vector parallel to its items; `Bucket::Sort`
-orders `(key, item)` pairs with plain tuple comparison and the bucket
-adopts the resulting item order.
+Sorting never calls `Column::lt` per comparison. When a bucket sorts,
+a key vector is built for its items and `Bucket::Sort` orders
+`(key, item)` pairs with plain tuple comparison; the bucket adopts
+the resulting item order.
 
 **Key shape.** The key is the comparator's own tuple, materialized
 once per item — the comparator remains the single source of ordering
@@ -123,37 +129,70 @@ and the suffix's first element) share one buffer; `uid` and `hash`
 are CoW copies of the `Item`'s own members and cost nothing while the
 item lives. Both facts are measured (spike section 4).
 
-**Lifetime and invalidation contract.** Keys are a cache of
-`(item content, active sort column, buyout state for Price/Date)`:
+**Residency: By-Tab keys are transient, By-Item keys are resident
+(R1-5).** By-Tab bucket keys are sorting scratch: built when the
+bucket sorts, discarded when that sort completes. What persists is
+the bucket's item *order* plus a per-bucket sorted-validity flag
+(D2); no structure above bucket grain ever holds By-Tab keys. The
+By-Item flat bucket alone keeps its key vector resident while that
+view is active — D4's merge probes need it. Build cost is O(bucket)
+— measured 33 ms per 100k items, 368 ms per 1m, so a 576-item bucket
+keys in well under a millisecond. Note this is strictly stronger
+than the spike's "cached keys" 40× path for By-Tab: a bucket whose
+sorted flag is valid does not re-sort *at all*; keys are rebuilt
+only when an order must actually be (re)established.
 
-1. Keys are built lazily, per bucket, the first time that bucket
-   sorts (composing with D2: collapsed buckets hold no keys). Build
-   cost is O(bucket) — measured 33 ms per 100k items, 368 ms per 1m,
-   so a 576-item bucket keys in well under a millisecond.
-2. A delta that replaces a bucket's items discards that bucket's
-   keys; they rebuild at the bucket's next sort (for a materialized
-   bucket, immediately — still O(delta)).
-3. Switching the active sort column discards all key vectors
-   (order-only changes — ascending/descending — do not; the
-   comparison flips, the keys stand). The rebuild is user-initiated
-   and O(materialized set); the whole-collection worst case is
-   ~0.37 s at 1m, paid once per column switch.
-4. When and only when the active column is Price or Date, every
-   `BuyoutManager` mutation path (item set/clear, tab set/clear, the
-   scoped and final pricing passes) marks dependent buckets'
-   key vectors stale. The implementation must enumerate these paths
-   at a single choke point; a design-review criterion checks the
-   enumeration, and `priceKeysFollowBuyoutEdits` pins the observable
-   behavior. Other columns' keys are indifferent to buyout state by
-   construction.
+**Invalidation contract.** An order (and the By-Item key vector) is
+a cache of `(item content, active sort column, buyout state for
+Price/Date)`. Invalidation therefore acts on sorted flags and the
+By-Item keys — never on By-Tab key caches, which don't exist:
+
+1. A delta that changes a bucket's items clears that bucket's sorted
+   flag; a *visible* (D2) bucket re-establishes order as part of the
+   delta's application — still O(delta + bucket). By-Item: the merge
+   itself maintains order and keys (D4).
+2. Switching the active sort column clears every sorted flag and
+   discards the By-Item key vector; visible buckets re-sort (each a
+   transient build + sort), collapsed ones simply stay flagged
+   unsorted. The whole-collection worst case (By-Item, or everything
+   expanded) is ~0.5 s at 1m, user-initiated, once per switch.
+3. Flipping only the direction re-sorts visible buckets with the
+   flipped comparison (By-Tab rebuilds transient keys — bucket-grain,
+   trivially cheap; By-Item re-sorts on its resident keys) and clears
+   collapsed buckets' flags.
+4. `BuyoutManager` mutations invalidate Price/Date-dependent order.
+   The implementation must route every mutation path through a single
+   choke point, and the inventory is exhaustive (R1-6): item
+   set-and-clear, tab set-and-clear, **migration**
+   (`MigrateItem`/`MigrateTab`, `buyoutmanager.cpp:369` — it changes
+   the lookup result), and the scoped and final pricing passes. A
+   design-review criterion checks the enumeration.
+
+**Buyout observability and batching (R1-6).** Three rules make the
+invalidation observable and bounded:
+
+- **User edits apply immediately**: with Price or Date active, an
+  edit reorders the affected visible scope now.
+- **Pricing passes batch**: the scoped per-delta pass and the final
+  passes accumulate invalidations and emit **one** batch at pass
+  end — at most one reorder/model update per pass, never one per
+  `Set` (`pricingPassYieldsSingleModelUpdate` pins it; the quadratic
+  per-`Set` reorder of the flat bucket is the failure this rule
+  exists to prevent).
+- **Cell repaint is independent of the active sort column**:
+  Price/Date *cells* render buyout state unconditionally
+  (`PriceColumn::value` reads the manager), so affected visible rows
+  get `dataChanged` on any buyout batch regardless of what column
+  sorts the view; only *reordering* is gated on the active column
+  (`priceCellsRepaintUnderAnySortColumn`).
 
 **Memory.** Measured (spike section 4): ~286 B/item accounted for the
-string-heavy worst case. Under D2's lazy per-bucket build the
-resident set is proportional to the materialized set — a collapsed
-default view holds approximately no keys. The documented worst case
-is the By-Item flat bucket at 1m with a base column active: ~266 MB
-naive, ~222 MB with the required `s2`/suffix sharing (D4 accepts
-this; the budget is pinned in the acceptance criteria).
+string-heavy worst case. Under the residency rule, resident key
+memory is the By-Item flat bucket **only**: ~266 MB naive at 1m,
+~222 MB with the required `s2`/suffix sharing (D4 accepts this; the
+budget is pinned in the acceptance criteria). By-Tab's transient
+peak is a single bucket — ~0.2 MB at the 576-item cap — regardless
+of collection size or how many buckets are expanded.
 
 Reasons:
 
@@ -171,28 +210,47 @@ Reasons:
 ### D2. Deferred sorting: only visible order is paid for (hold point, lever B)
 
 A bucket's item order is established only when that order can be
-seen. Each bucket carries a sorted flag (per search, per model):
+seen. Each bucket carries a sorted-validity flag (per search, per
+model), and the flag-and-order lifecycle is a complete state machine
+(R1-5) — every transition is listed here; there are no others:
 
-1. A **collapsed** By-Tab bucket is never sorted; it keeps arrival
-   order. Unsorted is not unstable: the order is deterministic until
-   a delta or refilter changes the bucket's contents, so persistent
-   indexes and model invariants hold.
-2. Expanding a bucket sorts it first (building its keys per D1 if
-   absent), then the expansion proceeds. Cost is bounded by the
-   576-item bucket cap: ~3 ms even with the *current* comparator,
-   microseconds keyed — imperceptible against the expand paint
-   itself. The same rule serves `RestoreViewExpansion`: restoring N
-   expanded buckets sorts exactly those N.
-3. Filtered searches are default-expanded (`search.h:86`), so every
-   visible bucket of a filtered result sorts eagerly — acceptable
-   because a filtered result is small by construction; the expensive
-   case (whole collection, unfiltered) is exactly the case that
-   starts fully collapsed.
-4. The By-Item flat bucket is always visible and therefore always
+1. A **never-sorted** collapsed By-Tab bucket keeps arrival order.
+   Unsorted is not unstable: the order is deterministic until a delta
+   or refilter changes the bucket's contents, so persistent indexes
+   and model invariants hold.
+2. **Expanding** a bucket whose flag is invalid sorts it first
+   (transient keys, D1), then the expansion proceeds. Cost is bounded
+   by the 576-item bucket cap: ~3 ms even with the *current*
+   comparator, microseconds keyed — imperceptible against the expand
+   paint itself. The same rule serves `RestoreViewExpansion`:
+   restoring N expanded buckets sorts exactly those whose flags are
+   invalid. Expanding a bucket whose flag is valid does no sort work.
+3. **Collapsing changes nothing** (R1-5): the sorted order and the
+   flag persist — collapse is a view event, not a model event.
+   Arrival order is never reconstructed; a bucket that has sorted
+   once simply stays sorted until invalidated. There are no keys to
+   evict, because By-Tab keys are transient (D1).
+4. **Invalidation** (content delta, column switch, direction flip,
+   buyout batch — D1's contract) clears flags; whether re-sorting
+   happens *now* is decided by visibility: visible buckets (expanded,
+   or By-Item) re-establish order as part of the invalidating event's
+   application; collapsed buckets defer to their next expansion.
+5. **Filtered searches are default-expanded** (`search.h:86`), so
+   every visible bucket of a filtered result sorts eagerly. The
+   honest worst case is a **broad filter** that matches nearly the
+   whole collection while expanding every bucket (R1-8 — `m_filtered`
+   is set by any single excluded item, `search.cpp:261-290`): the
+   ceiling is the transient build + sort of ~everything on top of the
+   filter loop, ~0.9 s estimated at 1m, with memory unaffected
+   (transient keys, one bucket at a time). This ceiling is accepted
+   and budgeted in M1-M3 (≤ 1.2 s at 1m); the collapsed-default win
+   applies to the unfiltered case only.
+6. The By-Item flat bucket is always visible and therefore always
    sorted (D4); lever B deliberately does not apply to it.
-5. Sort-column header clicks re-sort **materialized** buckets only
-   (per D1 rule 3) via the existing `layoutChanged` path; collapsed
-   buckets simply drop their sorted flag.
+7. Sort-column header clicks and direction flips re-sort **visible**
+   buckets only (D1 rules 2–3) via the existing `layoutChanged`
+   path; collapsed buckets' flags clear and their sort defers to
+   expansion.
 
 Reasons:
 
@@ -203,8 +261,9 @@ Reasons:
 - The hold point weighed B's bounded marginal value post-A (~0.13 s
   of a ~0.55 s filter-bound refilter at 1m) against its bookkeeping
   and committed it anyway, buying the collection-size-independent
-  first paint and the lazy key memory profile (D1) — B is what makes
-  "approximately no keys resident by default" true.
+  first paint — and, under R1-5's transient keys, B's flag caching
+  is what lets an already-sorted bucket skip re-sorting entirely,
+  which is stronger than any key cache.
 - The lazy machinery extends an existing pattern (`m_sorted` +
   sort-on-activation, `search.cpp:461-466`) one level down, from
   model to bucket, rather than inventing a new one.
@@ -215,24 +274,52 @@ The delta path stops resetting the model. When a delta intersects the
 current search (the M2 D9 intersection machinery, unchanged), it is
 applied as fine-grained operations scoped to the affected bucket:
 
-- **Content replacement** (`TabRefreshed`): one bucket-scoped
-  replace — remove that bucket's filtered rows, insert the arriving
-  items that pass the active filters, sorted if the bucket is
-  materialized (D2), arrival-ordered if collapsed. Item-level
-  diffing is deliberately rejected: M2 D2/D3 define the delta as a
-  whole-fetch-source replacement, so a one-bucket replace is the
+- **Content replacement** (`TabRefreshed`): a **source-scoped**
+  replace within the display bucket (R1-1) — remove exactly the rows
+  whose items were fetched from the delta's `FetchSourceKey`, insert
+  the arriving items that pass the active filters, sorted if the
+  bucket is visible (D2), arrival-ordered if collapsed. The
+  distinction matters because the display bucket keys on the stable
+  `(type, id)` and *aggregates* fetch sources: a Map/Unique child
+  shares its parent's bucket with its siblings, and M2 D2's accepted
+  mixed-generation behavior requires a child's delta to leave
+  sibling sources untouched
+  (`childDeltaPreservesSiblingSourcesInParentBucket`). For an
+  ordinary tab the source and the bucket coincide and this reduces
+  to the whole-bucket replace. Item-level diffing *within* a source
+  is still deliberately rejected: M2 D2/D3 define the delta as a
+  whole-fetch-source replacement, so source-scoped replace is the
   delta's native grain.
 - **Child reconciliation** (`ChildrenReconciled`): the erase becomes
-  row removals scoped to the parent's bucket.
+  row removals scoped to the parent's bucket — already
+  source-predicate-shaped (keys outside the expected set), matching
+  the replacement's grain.
 - **New tab discovered**: the bucket row is inserted at its display
   position (`begin/endInsertRows` at top level). **Deletion stays a
   snapshot-boundary effect** (M2 D6): an empty delta empties a
-  bucket, it never removes one.
+  bucket, it never removes one — removal happens at the final
+  reconciliation below.
 - **Metadata changes** (rename, move, color): the bucket row updates
   in place (`dataChanged`) and repositions with `beginMoveRows` when
   display ordering changes; expansion and selection follow the
   stable `(type, id)` key exactly as in M2 R6-3 — the machinery the
   parent plan carries forward as M3's bucket keying.
+- **The intersection contract gains a metadata half (R1-4).** M2's
+  item-based intersection deliberately had no metadata-only trigger
+  (M2 D6/R7-2): an empty delta carrying a rename, move, color, or a
+  newly discovered empty tab waited for the next refilter or the
+  final snapshot — tolerable when application meant an expensive
+  reset, wrong once application is a `dataChanged`. Rule: every
+  delta's location anchor lands in the canonical inventory
+  immediately (existing M2 machinery), and a delta whose stable key
+  owns a visible bucket — or would create one in an unfiltered
+  search (new empty tab) — applies its metadata **now**, item
+  intersection notwithstanding. M2 R7-2's exception is explicitly
+  renegotiated and retired: metadata-only deltas are no longer
+  outside any freshness statement, and the "invisible until user
+  action after terminal failure" caveat disappears
+  (`metadataDeltaAppliesWithoutItemIntersection`). Filtered searches
+  still hide empty buckets (`search.cpp:277-286`), unchanged.
 - **Search-side indexes are maintained incrementally**: the delta
   updates `m_visible_by_id`, `m_visible_sources`(`_by_tab`), and the
   bucket in O(delta); no whole-collection rebuild rides along. The
@@ -245,19 +332,59 @@ items with `MatchesActiveFilters`, keyed sort of ≤ 576 items, row
 ops). Deltas apply as they arrive; the freshness bound M2 D9 stated
 becomes trivially "immediate", and M2's hard constraint ("no
 per-delta uncoalesced model reset") is honored by having no reset at
-all. Rule 1 (every delta marks every search items-dirty) and
-dirty-on-activation for background searches are unchanged.
+all.
+
+**Dirty flags: renegotiated for the active search only (R1-7).** M2
+D9 rule 1 marked *every* search items-dirty per delta, the current
+one included, because the throttled reset was the only application
+mechanism. Post-M3 the active search processes every delta — either
+applying operations or correctly adjudicating "no visible change"
+(fails intersection, matches no filter) — so a delta it has
+processed leaves it **clean**; marking it dirty anyway would buy a
+spurious full refilter on the next switch-away-and-back
+(`appliedDeltasLeaveActiveSearchClean`). Fail-safe direction: any
+delta whose application was *skipped* for any reason leaves the flag
+dirty, and the final reconciliation clears it. Background searches
+keep rule 1 and dirty-on-activation verbatim.
 
 **The final snapshot stops being a destructive event for the open
-window.** On `ItemsRefreshed` after a refresh, the current search —
-already delta-fresh — performs one non-destructive reconciliation:
-bucket metadata refresh against the rebased locations
-(`RebaseItemLocations` runs at the success terminal, a
-snapshot-boundary effect per M2 D6) and bucket reordering via move
-ops. No `beginResetModel`. Background searches keep the existing
-flag-and-refilter-on-activation path. A full refresh with the window
-open is then, as the parent plan requires, just N deltas plus one
-cheap reconciliation — no special destructive path left.
+window — but it is an authoritative row reconciliation, not just a
+metadata pass (R1-2).** M2 D6 keeps three worker mutations
+snapshot-boundary-only that no delta expresses: deleted tabs dropped
+with their items, newly discovered unfetched tabs, and the location
+rebase (`RebaseItemLocations`, success only). A metadata-and-moves
+pass would therefore retain deleted content and omit new empty tabs
+indefinitely. On `ItemsRefreshed` after a refresh, the active search
+performs **one reconciliation pass diffing its model against the
+post-snapshot published state per stable key**: buckets (and rows)
+for deleted tabs removed, newly listed tabs inserted at their
+display positions (unfiltered searches — filtered ones still hide
+empty buckets), metadata refreshed against the rebased locations,
+bucket order corrected via move ops. Row operations only — no
+`beginResetModel`; O(collection) once per refresh is accepted
+(`finalReconciliationRemovesDeletedTabs`,
+`finalReconciliationInsertsNewlyListedEmptyTabs`). Background
+searches keep the existing flag-and-refilter-on-activation path. A
+full refresh with the window open is then, as the parent plan
+requires, just N deltas plus one reconciliation — no special
+destructive path left.
+
+**Selection is an intent, not a row (R1-3).** Immediate application
+creates a window the throttled world never had: an item moving
+between tabs arrives as a removal delta and, later, an insertion
+delta — and M2 R6-3's cross-tab pin
+(`reselectionSurvivesCrossTabMove`) requires selection to survive
+that. The contract: the selection *intent* is the stable item id,
+held independently of row existence. During an active refresh
+(first delta to final reconciliation), removing the selected item's
+row keeps the intent alive (the visual selection may lapse); any
+later delta inserting an item with that id — any bucket, any view —
+re-adopts the selection through the global identity index. The
+intent is cleared by the final reconciliation completing without
+the id present, or by the user selecting something else. Outside an
+active refresh, a removal clears selection immediately, as today.
+Pinned by `selectionIntentSurvivesCrossTabMoveAcrossDeltas` — the
+successor of M2's pin under no-reset machinery.
 
 **Where resets remain legitimate**: initial population (nothing to
 preserve) and user-initiated structural changes — filter edits, view-
@@ -390,12 +517,36 @@ Model-level (Qt Test, against the `MainWindow` fixture and a direct
 - `noModelResetDuringRefresh` — a complete refresh (N deltas, child
   reconciliations, terminal, final snapshot) with the window open
   emits zero `begin`/`endResetModel` on the current search's model;
-  the final snapshot performs only the D3 reconciliation
-  (metadata `dataChanged` + `beginMoveRows` repositioning).
-- `deltaReplacesExactlyItsBucketRows` — a content delta's row
-  operations touch exactly the affected bucket; row accounting,
-  filtered membership, and (for a materialized bucket) keyed order
-  all correct after application.
+  the final snapshot performs only the D3 row reconciliation.
+- `deltaReplacesExactlyItsSourceRows` — a content delta's row
+  operations touch exactly the rows fetched from its
+  `FetchSourceKey` within the affected bucket; row accounting,
+  filtered membership, and (for a visible bucket) keyed order all
+  correct after application (R1-1).
+- `childDeltaPreservesSiblingSourcesInParentBucket` (R1-1) — with a
+  Map/Unique parent bucket holding parent items plus two children's
+  items, one child's delta replaces only that child's rows; the
+  sibling's and parent's rows are untouched (M2 D2's
+  mixed-generation behavior at the model layer).
+- `finalReconciliationRemovesDeletedTabs` (R1-2) — a refresh whose
+  list reconciliation deleted a tab: no delta removes its bucket;
+  the final snapshot's reconciliation removes the bucket and its
+  rows via row operations, and its items leave the visible indexes.
+- `finalReconciliationInsertsNewlyListedEmptyTabs` (R1-2) — a newly
+  discovered, unfetched (empty) tab appears as a bucket in an
+  unfiltered search at the final reconciliation, at its display
+  position; a filtered search continues to hide it.
+- `metadataDeltaAppliesWithoutItemIntersection` (R1-4) — empty
+  deltas carrying a rename, a move, a color change, and a
+  new-empty-tab discovery each apply immediately (`dataChanged` /
+  move / bucket insertion in an unfiltered search) with **no final
+  snapshot and no refilter**, and the applied state persists after a
+  terminal failure.
+- `appliedDeltasLeaveActiveSearchClean` (R1-7) — after the active
+  search applies (or correctly adjudicates) a series of deltas,
+  switching away and back triggers no refilter; a delta arriving
+  while application is impossible leaves the flag dirty, and the
+  final reconciliation clears it.
 - `emptyDeltaEmptiesBucketWithoutRemovingIt` — the M2 D6 boundary at
   the model layer: an empty replacement leaves an empty bucket row
   (unfiltered search), never a bucket removal.
@@ -429,16 +580,37 @@ Sort-correctness:
   N saved expansions sorts exactly those N buckets on restore.
 - `filteredSearchSortsAllVisibleBuckets` — a filtered
   (default-expanded) search presents every bucket sorted.
-- `keyCacheInvalidatedByDelta` — a delta replacing a materialized
-  bucket's items yields fresh keyed order immediately; stale keys
-  never order fresh items (probe: key rebuild counted for that bucket
-  alone).
-- `sortColumnSwitchRebuildsMaterializedKeysOnly` — switching the
-  active column rebuilds keys for materialized buckets only;
-  flipping only the direction rebuilds none.
+- `sortedOrderSurvivesCollapse` (R1-5) — expand (sort), collapse,
+  re-expand with no intervening invalidation: no key build and no
+  sort runs the second time (probe counters), and the order is the
+  sorted one; arrival order is never reconstructed.
+- `collapsedInvalidBucketResortsOnReexpand` (R1-5) — expand,
+  collapse, replace the bucket's contents by delta, re-expand: the
+  bucket re-sorts exactly once, correctly.
+- `byTabKeysAreTransient` (R1-5) — after any By-Tab sort completes,
+  no key storage remains (probe: live key-vector count returns to
+  zero); only the By-Item flat bucket holds resident keys while
+  active.
+- `staleOrderNeverSurvivesDelta` — a delta replacing a visible
+  bucket's items yields fresh keyed order as part of application;
+  stale order never persists on a visible bucket (probe: sort
+  counted for that bucket alone).
+- `sortColumnSwitchResortsVisibleBucketsOnly` (R1-5) — switching the
+  active column clears every sorted flag but re-sorts visible
+  buckets only; a direction flip likewise; collapsed buckets sort at
+  their next expansion.
 - `priceKeysFollowBuyoutEdits` — with Price active, a user buyout
-  edit (item and tab level, set and clear) reorders affected rows;
-  Date symmetric; with Name active the same edits rebuild nothing.
+  edit (item and tab level, set and clear, **and migration** —
+  `MigrateItem`/`MigrateTab`, R1-6) reorders affected rows
+  immediately; Date symmetric; with Name active the same edits
+  reorder nothing.
+- `pricingPassYieldsSingleModelUpdate` (R1-6) — a scoped or final
+  pricing pass touching many items produces at most one reorder /
+  model update per pass on the active search (probe: model-update
+  count), never one per `Set`.
+- `priceCellsRepaintUnderAnySortColumn` (R1-6) — with Name active, a
+  buyout batch emits `dataChanged` for the affected visible
+  Price/Date cells and performs no reordering.
 
 By-Item:
 
@@ -449,8 +621,19 @@ By-Item:
   removes exactly the source's rows via row operations; no reset, no
   full re-sort.
 - `byItemSelectionSurvivesMerge` — a selected item retains selection
-  through a merge that moves its row; a removed item clears it
-  (stable-identity reselection at merge grain).
+  through a merge that moves its row; an item absent at the final
+  reconciliation clears it, while mid-refresh absence retains the
+  intent (R1-3).
+
+Selection intent (R1-3):
+
+- `selectionIntentSurvivesCrossTabMoveAcrossDeltas` — with an item
+  selected, one delta removes it from its tab; several deltas later
+  another inserts it in a different tab. The selection re-adopts the
+  item by stable id through the global index (M2
+  `reselectionSurvivesCrossTabMove`'s successor). If the refresh
+  ends without the id reappearing, the final reconciliation clears
+  the selection; a user selection made in between wins outright.
 
 Performance and memory (the M1-M3 checkpoint, Release, recorded
 environment, spike presets; budgets are the spike's measured ceilings
@@ -461,11 +644,14 @@ with headroom, misses gate completion the way M2-M2's did):
   (filter-loop-bound; the sort share ≤ 5 ms).
 - Single-bucket expand (cold keys): ≤ 10 ms at both scales.
 - By-Item full refilter: ≤ 250 ms at 100k, ≤ 1.5 s at 1m.
-- Delta application on the current search, By-Tab materialized
-  bucket: ≤ 5 ms at 1m; By-Item merge: ≤ 50 ms at 1m.
-- Resident key memory, active column, By-Item at 1m: ≤ 300 MB;
-  By-Tab default view: proportional to the materialized set
-  (≈ 0 collapsed).
+- Broad-filter default-expanded refilter (a filter matching ~all
+  items, every bucket visible — R1-8's worst case): ≤ 150 ms at
+  100k, ≤ 1.2 s at 1m.
+- Delta application on the current search, By-Tab visible bucket:
+  ≤ 5 ms at 1m; By-Item merge: ≤ 50 ms at 1m.
+- Resident key memory, active column: By-Item at 1m ≤ 300 MB;
+  By-Tab: transient only, single-bucket peak (≤ 1 MB) at any scale
+  and any expansion state (R1-5).
 
 Design-review criteria (checked in review, not runnable):
 
@@ -479,10 +665,15 @@ Design-review criteria (checked in review, not runnable):
 - Keys are derived from the comparators, which remain the single
   source of ordering truth; no code path defines order twice.
 - D1 rule 4's `BuyoutManager` mutation enumeration is complete —
-  every mutation path flows through the single choke point that
-  marks Price/Date keys stale.
-- M2's intersection, dirty-flag, and background-search machinery is
-  unchanged; the persistence and presentation lanes still share no
+  every mutation path, **migration included** (R1-6), flows through
+  the single choke point — and the batching rules hold: pricing
+  passes emit one batch, user edits apply immediately, cell repaint
+  is independent of the active sort column.
+- M2's intersection and background-search machinery is inherited
+  with exactly two stated renegotiations, neither silent: the
+  metadata half added to the intersection contract (R1-4, retiring
+  M2 R7-2's exception) and rule 1 relaxed for the active search only
+  (R1-7). The persistence and presentation lanes still share no
   payload types, and keys carry no wire or `poe::*` types.
 - The retirement of the D9 throttle deletes its machinery and its
   pinned timer tests by renegotiation, not silent breakage — the M2
@@ -529,5 +720,10 @@ Design-review criteria (checked in review, not runnable):
 | Hold point (Tom, July 30, 2026): levers A+B committed; intended order; memory measured pre-freeze | D1, D2, D5; spike section 4 |
 | M2 hard constraint: no per-delta uncoalesced model reset; freshness bound | D3 (no reset at all; throttle retired, bound trivially met) |
 
-Every named input is consumed. Review rounds begin at round 1 in
-`items-pipeline-m3-reviews.md`, which also carries the revision log.
+Every named input is consumed. Review round 1 (R1-1…R1-8, July 30,
+2026, all accepted) is incorporated throughout — verdicts and
+resolutions in `items-pipeline-m3-reviews.md`, which also carries
+the revision log. The round's structural theme: revision 1
+specified the single-event grain and round 1 forced the sequence
+grain (source vs. display bucket, cross-delta selection state,
+snapshot-boundary rows, pricing-pass batching).

--- a/docs/design/items-pipeline.md
+++ b/docs/design/items-pipeline.md
@@ -332,7 +332,14 @@ the M2 spec:**
   maximum staleness — a throttle that guarantees the visible view is
   never more than a stated interval behind the applied state.
 
-### Milestone 3 — Delta-native items model (later)
+### Milestone 3 — Delta-native items model (spec drafted July 30, 2026: `items-pipeline-m3.md`, revision 1, in review)
+
+The "profile before choosing levers" obligation below was discharged
+July 30, 2026 by the S1-M3 sort-profiling spike
+(`m3-sort-profile-result.md`; throwaway branch `spike/m3-sort-profile`,
+never merged) and the same-day lever hold point, whose decisions the
+spec records. The inputs below are kept as written; the spec's
+traceability table maps each to its consuming decision.
 
 Make Layer 3 consume deltas natively, eliminating the full reset:
 

--- a/docs/design/items-pipeline.md
+++ b/docs/design/items-pipeline.md
@@ -332,7 +332,7 @@ the M2 spec:**
   maximum staleness — a throttle that guarantees the visible view is
   never more than a stated interval behind the applied state.
 
-### Milestone 3 — Delta-native items model (spec drafted July 30, 2026: `items-pipeline-m3.md`, revision 1, in review)
+### Milestone 3 — Delta-native items model (spec drafted July 30, 2026: `items-pipeline-m3.md`, revision 2, in review — round 1 incorporated)
 
 The "profile before choosing levers" obligation below was discharged
 July 30, 2026 by the S1-M3 sort-profiling spike

--- a/docs/design/items-pipeline.md
+++ b/docs/design/items-pipeline.md
@@ -332,7 +332,7 @@ the M2 spec:**
   maximum staleness — a throttle that guarantees the visible view is
   never more than a stated interval behind the applied state.
 
-### Milestone 3 — Delta-native items model (spec drafted July 30, 2026: `items-pipeline-m3.md`, revision 2, in review — round 1 incorporated)
+### Milestone 3 — Delta-native items model (spec drafted July 30, 2026: `items-pipeline-m3.md`, revision 3, in review — rounds 1–2 incorporated)
 
 The "profile before choosing levers" obligation below was discharged
 July 30, 2026 by the S1-M3 sort-profiling spike

--- a/docs/design/m3-sort-profile-result.md
+++ b/docs/design/m3-sort-profile-result.md
@@ -1,0 +1,305 @@
+# M3 sort-profile result (input to the M3 spec)
+
+Status: **MEASURED July 30, 2026** — the profiling evidence the parent
+plan's M3 inputs require before the M3 spec picks its central lever
+("profile before choosing levers", S1-M2 amendment finding 5). This is
+a spike result in the R3-4 tradition: produced on the throwaway branch
+`spike/m3-sort-profile` (off master 3549b214, the M2 merge), whose
+prototype code is never merged; this document is the deliverable. **No
+lever is selected here** — bounds are established; selection belongs
+to the M3 spec.
+
+Headline: **the comparator claim is proven, and sharpened.** The
+post-reset whole-model re-sort is comparator-bound, and the dominant
+cost inside the comparator is not string comparison or allocation but
+the **two `QRegularExpression` evaluations `Column::multivalue` runs
+per side on every comparison** — roughly three quarters of every
+comparator call, paid twice per comparison, ~10 million comparisons
+per refilter at 1m. Columns with custom comparators that skip
+`multivalue` entirely (Price, Date) sort the same buckets **7×
+cheaper**; a precomputed-key prototype sorts them ~40× cheaper
+(~10× including per-refilter key rebuild).
+
+## What was measured
+
+Three groups, at both scales (100k and 1m presets):
+
+1. **The live full-refilter split** on the real production path:
+   `MainWindow::OnItemsRefreshed` → `Search::FilterItems` (begin-reset
+   / filter loop / bucket display ordering / end-reset) →
+   `setSortingEnabled(true)` → `ItemsModel::sort` → `Search::Sort`
+   over every bucket — reconfirming the S1-M2 whole numbers on
+   current master, now with the sort's interior attributed.
+2. **Comparator attribution**: live comparator invocation counts and
+   multivalue-path counts (probes in `Column::lt`,
+   `Column::multivalue`, `PriceColumn::lt`, `DateColumn::lt`,
+   `Item::operator<`); micro-benchmarks on copies of the published
+   collection — per-column bucket-sort cost, and per-call component
+   costs of the NameColumn comparator (QVariant `value()`,
+   `toString()`, the two regexes, `PrettyName()`, the tie-break).
+3. **Lever bounds** (prototype quality, no decisions): a
+   precomputed-sort-key variant and a sort-only-expanded-buckets
+   variant, on the same bucket shapes the live path sorts, plus the
+   By-Item single flat bucket both ways. **Born-sorted buckets
+   (filtering from a pre-sorted master) was not prototyped** — its
+   ceiling is implied by the keyed numbers but not measured.
+
+Instrumentation: `src/util/spikeprofile.h` (spike-only globals) with
+probes in `search.cpp`, `items_model.cpp`, `column.cpp`, `item.cpp`,
+and `mainwindow.cpp`; harness `tests/m3_sort_benchmark.cpp` (target
+`m3_sort_benchmark`, `EXCLUDE_FROM_ALL`). All of it lives only on the
+spike branch. Reproduce with:
+
+```
+cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH=/Users/tom/Qt/6.11.1/macos
+cmake --build build-release --target m3_sort_benchmark -j 8
+./build-release/tests/m3_sort_benchmark --preset 100k   # and --preset 1m
+```
+
+## Environment (per the M2-M2 conventions)
+
+- Hardware: Apple M4, 32 GB RAM (macMini-class), macOS 26.6
+  (Darwin 25.6.0)
+- Compiler: Apple clang 21.0.0 (clang-2100.1.1.101), arm64
+- Qt 6.11.1 (release build), offscreen QPA platform
+- Build: CMake `Release` (`-O3`), separate `build-release/` tree
+- Allocator: system malloc (no substitution)
+- Logging: spdlog level `info` (production default)
+
+## Datasets and shapes
+
+`tests/spikedataset.h`, seed 20260729 — the same presets as S1-M2 and
+M2-M2 (note: the generator's stash ids were shortened July 30, after
+the recorded M2-M2 runs; irrelevant to sort cost):
+
+| Preset | tabs | mean items/tab | quad share | published items |
+|---|---|---|---|---|
+| 100k | 2000 | 50 | 0.10 | 101,048 |
+| 1m | 2600 | 400 | 0.80 | 975,711 |
+
+The collection is published once through the production snapshot path
+(`ItemsManager::OnItemsRefreshed`), then the measured unit is
+`MainWindow::OnItemsRefreshed()` — the worst-case unfiltered
+refilter-plus-resort of the whole collection on the single unfiltered
+default search, By-Tab view, default sort (column 0 = Name,
+**descending** — the model's pinned default). 1 warmup + 5 measured
+reps at 100k, + 3 at 1m; reported statistic is the **median** (spread
+across reps and across a full rerun was within ±3%).
+
+## 1. Live full-refilter split
+
+All values ms, median. "—" marks components below 0.01 ms.
+
+| Component | 100k | 1m |
+|---|---|---|
+| **whole `OnItemsRefreshed`** | **422.5** | **5,561.9** |
+| `FilterItems` total | 35.2 | 398.1 |
+| — begin reset (`beginResetModel`) | — | — |
+| — filter loop + bucketing | 34.4 | 391.3 |
+| — bucket display ordering | 0.8 | 6.8 |
+| — end reset (view rebuild) | 0.01 | 0.01 |
+| `setSortingEnabled(true)` → `ItemsModel::sort` | 386.8 | 5,163.0 |
+| — `Search::Sort` (per-bucket `std::sort`) | 386.8 | 5,162.9 |
+| — everything else in `ItemsModel::sort`¹ | — | — |
+| `RestoreViewExpansion` | 0.04 | 0.06 |
+| Reselect + scroll restore | 0.6 | 0.7 |
+
+¹ `layoutAboutToBeChanged`/`layoutChanged` emits, the persistent-index
+snapshot, and the remap are all ≤ 0.005 ms — there were no persistent
+indexes below bucket level in the harness run (no expansion, no
+selection). With expanded tabs and a selection they cost more, but
+S1-M2 already bounded the whole restore side collectively at a few ms.
+
+This reconfirms the S1-M2 whole numbers on current master: their
+~455 ms / ~5,370 ms resets (sort ~390 / ~5,040–5,076) against our
+422 / 5,562 (sort 387 / 5,163) — same shape, within ~5–10% across a
+somewhat different measured boundary (S1-M2's window was the throttled
+tick, capture → scroll restored; ours is the plain
+`OnItemsRefreshed` call).
+
+**The model reset itself is ~free; the "reset cost" is the re-sort.**
+`beginResetModel`/`endResetModel` are microseconds. The filter loop is
+the only other real cost (~7% of the total at both scales), and the
+sort is ~92–93%, all of it inside `Bucket::Sort`'s `std::sort` calls.
+
+Live comparator counts (Name column, descending):
+
+| | 100k | 1m |
+|---|---|---|
+| `Column::lt` calls | 728,360 | 9,842,111 |
+| live ns per comparison | ~531 | ~525 |
+| `multivalue` calls (2 per lt) | 1,456,720 | 19,684,222 |
+| multivalue path | 100% string (both regexes fail) | same |
+| tie-break `Item::operator<` reached | 16.6% | 34.9% |
+
+## 2. Inside the comparator — the claim proven
+
+**Per-column bucket sort** (micro, fresh copies of the same buckets,
+descending; live-equivalent — the Name row matches the live sort
+within 1%):
+
+| Column | 100k ms | ns/compare | 1m ms | ns/compare |
+|---|---|---|---|---|
+| Name (default sort) | 385.2 | 529 | 5,116.4 | 520 |
+| Property "Q" (Quality) | 340.2 | 466 | 4,603.0 | 468 |
+| ilvl | 351.2 | 483 | 4,849.3 | 493 |
+| **Price (custom `lt`, no multivalue)** | **52.4** | **72** | **719.5** | **73** |
+| **Date (custom `lt`, no multivalue)** | **53.1** | **73** | **728.4** | **74** |
+
+Every column that routes through `Column::multivalue` costs
+~470–530 ns/compare; the two columns with bespoke comparators that
+never touch it cost ~72–74 ns — **a 7× spread on identical buckets**.
+Crucially, **ilvl is numeric and still costs 483–493 ns**: its value
+matches the first regex immediately, so even the regex *fast path*
+pays the full toll. The multivalue machinery, not the data type, is
+the cost.
+
+**Component costs** (NameColumn, fixed random-pair sample; each row is
+the cost of doing that work for both sides of one comparison):
+
+| Component (both sides) | 100k ns/call | 1m ns/call |
+|---|---|---|
+| **full `Column::lt`** | **773** | **911** |
+| `value()` (QVariant of `PrettyName`) | 96 | 134 |
+| `value().toString()` | 119 | 166 |
+| toString + **both regexes** | 721 | 862 |
+| `PrettyName()` alone | 80 | 116 |
+| replicated multivalue (full key build) | 910–994 | 1,030 |
+| `Item::operator<` tie-break alone | 95 | 124 |
+
+Attribution reading (ratios, not exact addends — see caveats): of a
+~773–911 ns comparator call, the toString-plus-regex stage accounts
+for ~93–95%, and subtracting the toString cost leaves **the two
+`QRegularExpression::contains` evaluations at roughly 600–700 ns per
+comparison — about three quarters of the whole comparator**. The
+QVariant/QString conversions and the `PrettyName()` allocations
+(1 QString concatenation per call for named items) are the next terms
+at roughly 10–20% combined; the tie-break, when reached, adds ~100 ns
+(two more `PrettyName` allocations plus QString compares). The
+`std::sort` machinery itself is ~12–13 ns/compare (measured by the
+keyed sort below).
+
+For the default Name sort both regexes *always* fail (item names never
+look like `12`, `+16%`, or `12-14`), so the string path runs
+every time: 4 regex evaluations + 4 `PrettyName()`-class allocations +
+2 QString tuple copies per comparison, at ~10M comparisons per 1m
+refilter.
+
+## 3. Lever bounds (ceilings, not decisions)
+
+**A. Precomputed sort keys** (build the multivalue tuple + tie-break
+key once per item; sort with plain tuple compares — QString relational
+compares remain, no QVariant/regex/allocation per comparison):
+
+| | 100k | 1m |
+|---|---|---|
+| key build (once per item) | 33.1 ms | 367.5 ms |
+| sort with cheap compare | 8.5 ms (11.6 ns/cmp) | 129.9 ms (13.2 ns/cmp) |
+| **build + sort vs live sort** | **41.6 vs 386.8 ms (9.3×)** | **497.4 vs 5,163.0 ms (10.4×)** |
+| sort alone (keys already valid) | 8.5 ms (45×) | 129.9 ms (40×) |
+
+Even rebuilding every key on every refilter beats the current sort by
+~10×; if keys survive across refilters (they depend only on item
+content and, for Price/Date, buyout state), the re-sort itself drops
+to ~40×. A 1m worst-case refilter's sort would go from ~5.2 s to
+~0.5 s (rebuild) or ~0.13 s (cached keys).
+
+**B. Sort only expanded/visible buckets** (the K largest buckets stand
+in for a worst-case expanded set; per-tab caps bound each bucket at
+576 items):
+
+| | 100k | 1m |
+|---|---|---|
+| top 5 buckets | 14.7 ms (2,792 items) | 15.9 ms (2,880 items) |
+| top 20 buckets | 34.4 ms (6,919 items) | 62.8 ms (11,520 items) |
+
+The cost becomes proportional to the *expanded set*, independent of
+collection size. Note the default view starts fully collapsed (an
+unfiltered By-Tab search), so the deferred work at first paint is the
+entire sort.
+
+**By-Item flat bucket** — the structure that fights both levers
+(single bucket holding everything; lever B cannot help it at all):
+
+| | 100k | 1m |
+|---|---|---|
+| real comparator | 1,017.0 ms | 12,874.5 ms |
+| precomputed keys (build + sort) | 33.4 + 27.2 ms | 371.3 + 393.4 ms |
+
+The flat sort is ~2.5× worse than the By-Tab sort of the same items
+(larger n per `std::sort`, higher tie rate) — **~12.9 s at 1m today**
+— and the keyed variant collapses it to ~0.77 s.
+
+## Attribution notes and honest caveats
+
+- **Probe overhead is negligible and common-mode.** The live and micro
+  Name sorts agree within 1% and both include the same counters (a
+  few increments per comparison against a ~520 ns comparison). The
+  per-bucket timer pairs add ~2 × 2,600 clock reads per sort.
+- **The random-pair component sample is not the in-sort access
+  pattern.** Micro per-call costs (773–911 ns) exceed the live
+  per-comparison cost (~520–530 ns) because random pairs touch the
+  whole collection cache-cold while `std::sort` works one
+  cache-warm bucket at a time. Component rows are therefore reliable
+  as *ratios* (what fraction of a comparator call each stage is), not
+  as absolute addends to the live number.
+- **Dataset name diversity is artificially low** (16 prefixes × 12
+  suffixes × 18 bases), which inflates the tie-break rate (16.6% at
+  100k, 34.9% at 1m — real accounts should tie less). The tie-break
+  is a ~100–124 ns term; the regex cost per comparison does not
+  depend on name diversity, so the headline attribution stands.
+- **Price/Date buyout lookups ran against an all-default
+  `BuyoutManager`** (the dataset carries no notes and no buyouts were
+  set), so their ~72–74 ns may understate a priced account's cost;
+  they cannot approach multivalue's cost regardless of the lookup.
+- **No paint**: offscreen numbers, as in S1-M2. The restore-side
+  machinery ran with no expansion/selection state, so the
+  persistent-index snapshot/remap costs in `ItemsModel::sort` were
+  measured at their floor (S1-M2's collective few-ms bound covers the
+  realistic case).
+- **The lever prototypes take no positions**: key invalidation (item
+  churn, buyout edits invalidating Price/Date keys), key memory
+  (~4 QStrings + 2 doubles per item — not measured), per-bucket
+  sortedness bookkeeping and sort-on-expand latency for lever B, and
+  the born-sorted-master alternative are all M3 spec work. The
+  numbers here are achievable ceilings under the current comparator
+  semantics, nothing more.
+- **The By-Item flat sort's comparison count was not separately
+  counted** (time only); the compare counts in the per-column table
+  are exact.
+- Measured on the spike branch off master 3549b214; the full ctest
+  suite passes on the branch with the instrumentation in place.
+
+## New findings routed to the register
+
+- **F67** — `Item::operator<` compares `m_hash` against itself (the
+  tie-break tuple's third element is the lhs hash on both sides), so
+  the hash tie-break is dead code. Harmless today; recorded in
+  `docs/cleanup/findings.md` with the M3-relevant consequence: a
+  precomputed-key design must choose between reproducing the
+  *intended* `(name, uid, hash)` order and the *actual* `(name, uid)`
+  one.
+
+## What this gives the M3 spec (evidence, not decisions)
+
+1. **The suspected driver is confirmed and localized.** The sort is
+   comparator-bound; the comparator is regex-bound (~3/4 of each
+   call), with QVariant/QString conversion and `PrettyName`
+   allocation as the second-order terms. Any lever that stops paying
+   `multivalue` per comparison captures most of the available win —
+   and conversely, micro-optimizing the regexes alone (e.g. cheaper
+   parsing) could plausibly get a large fraction of lever A's win
+   without precomputation, though that variant was not prototyped.
+2. **Both named levers have large, now-quantified ceilings** —
+   precomputed keys ~10× (rebuild-per-refilter) to ~40× (cached),
+   expanded-only proportional-to-expanded — and they compose: they
+   attack independent factors (cost per comparison vs number of
+   comparisons).
+3. **The By-Item flat bucket is the worst structure by far**
+   (~12.9 s at 1m) and lever B cannot help it; whatever M3 chooses
+   must have an answer for it (lever A alone brings it to ~0.77 s).
+4. The model-reset side of the old "reset cost" story is dead: begin/
+   end reset are microseconds, and the filter loop (~0.4 s at 1m) is
+   the second-largest component after the sort — worth keeping in
+   frame once the sort stops dominating.

--- a/docs/design/m3-sort-profile-result.md
+++ b/docs/design/m3-sort-profile-result.md
@@ -43,6 +43,11 @@ Three groups, at both scales (100k and 1m presets):
    By-Item single flat bucket both ways. **Born-sorted buckets
    (filtering from a pre-sorted master) was not prototyped** — its
    ceiling is implied by the keyed numbers but not measured.
+4. **Key memory** (added July 30 at the M3 lever hold point, as the
+   pre-freeze extension that hold point requested): bytes per
+   precomputed key for the whole published collection, measured for
+   the key shape the M3 spec carries — the multivalue tuple plus the
+   *intended* `(name, uid, hash)` tie-break (F67). See section 4.
 
 Instrumentation: `src/util/spikeprofile.h` (spike-only globals) with
 probes in `search.cpp`, `items_model.cpp`, `column.cpp`, `item.cpp`,
@@ -230,6 +235,39 @@ entire sort.
 The flat sort is ~2.5× worse than the By-Tab sort of the same items
 (larger n per `std::sort`, higher tie rate) — **~12.9 s at 1m today**
 — and the keyed variant collapses it to ~0.77 s.
+
+## 4. Key memory (pre-freeze extension, July 30)
+
+Measured after the lever hold point selected levers A + B and the
+intended `(name, uid, hash)` tie-break order (see the M3 spec); the
+harness gained a section that builds the full-collection key vector
+(Name column — the string-heavy worst case, since both regexes fail
+and both string slots populate) and reports an accounted breakdown
+plus the RSS delta. The key struct is 2 doubles + 5 `QString`s + an
+`Item*` (`sizeof` 144 B).
+
+| | 100k | 1m |
+|---|---|---|
+| keys | 101,048 | 975,711 |
+| inline (vector storage) | 13.9 MB (144.0 B/item) | 134.0 MB (144.0 B/item) |
+| heap, fresh (`s1`/`s2`/`pretty`) | 13.7 MB (141.8 B/item) | 131.8 MB (141.7 B/item) |
+| heap, CoW-shared (`uid`/`hash`) | 15.6 MB | 150.7 MB |
+| **accounted total (inline + fresh)** | **27.5 MB (285.8 B/item)** | **265.8 MB (285.7 B/item)** |
+| `s2`/`pretty` dedupe would save | 4.6 MB | 43.9 MB |
+| RSS delta | 13.9 MB | 134.0 MB |
+
+Reading: a naive full-collection key store for the active sort column
+costs **~286 B/item accounted — ~266 MB at 1m**. The `uid` and `hash`
+strings are copies of the `Item`'s own members, so Qt's implicit
+sharing makes them free while the item lives (they are tallied
+separately above, not in the accounted total). Roughly a third of the
+fresh-heap term (44 MB at 1m) disappears if the two identical
+`PrettyName` strings (`s2`/`pretty`) share one buffer, which any real
+implementation would do. The RSS delta understates the accounted
+total because the allocator reuses pages freed by earlier harness
+sections; the accounted number is the honest per-item figure. Memory
+for anything smaller than the whole collection (per-expanded-bucket
+keys under lever B) scales down linearly with the keyed item count.
 
 ## Attribution notes and honest caveats
 


### PR DESCRIPTION
## Summary

Docs-only PR carrying the Milestone 3 spec (`docs/design/items-pipeline-m3.md`), its review record (`items-pipeline-m3-reviews.md`), and the S1-M3 sort-profiling spike evidence it consumes (`m3-sort-profile-result.md` + key-memory extension), plus the F67 register entry (dead hash tie-break — fixed by the spec's D5 when implementation lands).

**The spec is FROZEN at revision 4** (July 30, 2026) after:

- The S1-M3 spike (branch `spike/m3-sort-profile`, never merged): sort is ~92–93% of the worst-case refilter, comparator-bound, regex-bound; lever ceilings quantified; key memory measured (~286 B/item, ~266 MB naive at 1m).
- The lever hold point (Tom, July 30): levers A (cached sort keys) + B (deferred sorting) both committed; intended `(name, uid, hash)` tie-break order; key-memory measurement run pre-freeze.
- Three external review rounds, eighteen findings (R1-1…R1-8, R2-1…R2-6, R3-1…R3-4), all verified and accepted — verdicts and resolutions in the reviews file.
- A focused post-round-3 consistency check (key residency, activation ordering, nested batching), findings folded into revision 4.

## What the spec decides

- D1: sorting runs on precomputed cached keys derived from the comparators; residency scoped to the active search's materialized buckets, with an explicit hydration rule and invalidation contract.
- D2: only visible order is paid for — per-bucket sorted flags, collapsed buckets defer sorting.
- D3: refresh deltas become bucket-scoped model operations; the M2 D9 throttled reset is retired for the current search; the final snapshot is a non-destructive row reconciliation; selection becomes a stable-id intent.
- D4: the By-Item flat bucket gets a per-delta sorted merge (O(n + d)), keys resident while its search is active.
- D5: the F67 tie-break fix.
- D6/D7: user refilter kept (filter loop is the residual, deferred); deferrals recorded with reasons.

M1-M3 (the performance/memory budget checkpoint) gates M3 completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)