### PR TITLE
Guard forum updates against rejected POESESSID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ project(acquisition
 include(CTest)
 
 # Use this to define pre-releases
-set(app_version_suffix "-alpha.5")
+set(app_version_suffix "-alpha.6")
 
 # Variables used in version_defines.h and platforn-specific files and properties.
 set(app_name            "${CMAKE_PROJECT_NAME}")

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -125,6 +125,7 @@ void Application::InitUserSession()
     // the gate evaluates (the worker emits ItemsRefreshed before
     // RefreshFinished, so this holds by emission order regardless).
     connect(item_mgr, &ItemsManager::RefreshFinished, &shop(), &Shop::OnRefreshFinished);
+    connect(&shop(), &Shop::PoeSessionRejected, this, &Application::ClearSessionId);
 
     auto characters = &userstore().characters();
     auto stashes = &userstore().stashes();
@@ -339,14 +340,20 @@ void Application::InitCrashReporting()
     }
 }
 
+void Application::ClearSessionId()
+{
+    network_manager().clearPoeSessionId();
+    settings().remove("session_id");
+}
+
 void Application::SetSessionId(const QString &poesessid)
 {
     if (poesessid.isEmpty()) {
-        spdlog::error("Application: cannot update POESESSID: value is empty");
-        return;
+        ClearSessionId();
+    } else {
+        network_manager().setPoeSessionId(poesessid);
+        settings().setValue("session_id", poesessid);
     }
-    network_manager().setPoeSessionId(poesessid);
-    settings().setValue("session_id", poesessid);
 }
 
 void Application::SetTheme(const QString &theme)

--- a/src/application.h
+++ b/src/application.h
@@ -48,6 +48,7 @@ public:
     void InitLogin();
 
 public slots:
+    void ClearSessionId();
     void SetSessionId(const QString &poesessid);
     void SetTheme(const QString &theme);
     void SetUserDir(const QString &dir);

--- a/src/shop.cpp
+++ b/src/shop.cpp
@@ -34,6 +34,18 @@ namespace {
     constexpr int kMaxCharactersInPost = 50000;
     constexpr int kSpoilerOverhead = 19; // "[spoiler][/spoiler]" length
 
+    bool IsPoeSessionRejected(const QNetworkReply *reply)
+    {
+        const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        return status == 401 || status == 403;
+    }
+
+    bool IsPoeSessionRejected(const QByteArray &body)
+    {
+        return body.contains("Login Required") || body.contains("Permission Denied")
+               || body.contains("Content Denied");
+    }
+
     // Buyout grouping order for shop generation: items sharing one buyout
     // render under one spoiler.
     bool buyoutLess(const Buyout &a, const Buyout &b)
@@ -285,12 +297,16 @@ void Shop::OnStashIndexReceived(
     // classified — the transport check, the status check, and the parse
     // check this function used to do all live below the facade now.
     if (!result) {
-        if (result.error().kind == RateLimit::FetchError::Kind::Canceled) {
+        const auto &error = result.error();
+        if (error.kind == RateLimit::FetchError::Kind::Canceled) {
             spdlog::debug("Shop: the stash index request was canceled");
+        } else if (error.kind == RateLimit::FetchError::Kind::Http
+                   && (error.http_status == 401 || error.http_status == 403)) {
+            RejectPoeSession("legacy stash index returned HTTP 401/403");
         } else {
             spdlog::error("Shop: could not index stashes ({}): {}",
-                          RateLimit::ToString(result.error().kind),
-                          result.error().message);
+                          RateLimit::ToString(error.kind),
+                          error.message);
         }
         FailActiveJob();
         return;
@@ -312,6 +328,19 @@ void Shop::OnStashIndexReceived(
     }
 
     OnStashIndexUpdated();
+}
+
+void Shop::RejectPoeSession(const QString &reason)
+{
+    spdlog::warn("Shop: rejecting POESESSID: {}", reason);
+
+    m_waiting_capture.reset();
+    SetAutoUpdate(false);
+
+    emit PoeSessionRejected();
+    emit UserWarning("Path of Exile rejected the saved POESESSID. Acquisition has "
+                     "cleared it and disabled automatic forum updates as a precaution.\n\n"
+                     "Normal stash and character updates are unaffected.");
 }
 
 void Shop::ExpireShopData()
@@ -537,42 +566,31 @@ void Shop::OnEditPageFinished()
         return;
     }
     QNetworkReply *reply = qobject_cast<QNetworkReply *>(QObject::sender());
+
+    if (IsPoeSessionRejected(reply)) {
+        RejectPoeSession("forum edit page returned HTTP 401/403");
+        reply->deleteLater();
+        FailActiveJob();
+        return;
+    }
+
     const QByteArray bytes = reply->readAll();
+    if (IsPoeSessionRejected(bytes)) {
+        // The website may redirect an unauthenticated request to an error
+        // page whose final response is 200, so status alone is insufficient.
+        RejectPoeSession("forum edit page returned an authentication error page");
+        reply->deleteLater();
+        FailActiveJob();
+        return;
+    }
+
     const QString hash = Util::GetCsrfToken(bytes, "hash");
     if (hash.isEmpty()) {
-        if (bytes.contains("Login Required")) {
-            spdlog::error("Cannot update shop: the POESESSID is missing or invalid.");
-            emit UserWarning(
-                "Cannot update forum shop threads because POESESSID is missing or invalid."
-                "\n\n"
-                "Use the Shop --> 'Update Shop POESESSID' menu item."
-                "\n\n"
-                "This is required even if you have logged in with OAuth, because the forums do not "
-                "support OAuth.");
-
-            emit StatusUpdate(ProgramState::Ready,
-                              "Shop threads not updated to to missing or invalid POESESSID");
-
-        } else if (bytes.contains("Permission Denied")) {
-            spdlog::error("Cannot update shop: the POESESSID may be invalid or associated with "
-                          "another account.");
-            emit UserWarning(
-                "Cannot update forum shop threads because POESESSID is invalid or associated with "
-                "the wrong account."
-                "\n\n"
-                "Use the Shop --> 'Update Shop POESESSID' menu item."
-                "\n\n"
-                "This is required even if you have logged in with OAuth, because the forums do not "
-                "support OAuth.");
-            emit StatusUpdate(ProgramState::Ready,
-                              "Shop threads not updated to to missing or invalid POESESSID");
-
-        } else {
-            spdlog::error("Cannot update shop: unable to extract CSRF token from the page. The "
-                          "thread ID may be invalid.");
-            emit StatusUpdate(ProgramState::Ready, "Shop threads not updated due to an error.");
-        }
+        spdlog::error("Cannot update shop: unable to extract CSRF token from the page. The "
+                      "thread ID may be invalid.");
+        emit StatusUpdate(ProgramState::Ready, "Shop threads not updated due to an error.");
         FailActiveJob();
+        reply->deleteLater();
         return;
     }
     spdlog::trace("CSRF token found.");
@@ -638,19 +656,30 @@ void Shop::OnShopSubmitted(QUrlQuery query, QNetworkReply *reply)
         return;
     }
 
-    // Check for network errors.
+    const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    if (IsPoeSessionRejected(reply)) {
+        RejectPoeSession("forum submission returned HTTP 401/403");
+        FailActiveJob();
+        return;
+    }
+
+    // Check for transport errors. reply->error() is a Qt NetworkError enum,
+    // not an HTTP status; the response status lives in the request attribute.
     if (reply->error() != QNetworkReply::NoError) {
-        const int status = reply->error();
-        if ((status < 200) || (status > 299)) {
-            const QString msg = reply->errorString();
-            spdlog::error("Shop: network error submitting shop: {} {}", status, msg);
-            FailActiveJob();
-            return;
-        }
-        spdlog::debug("Shop: http reply status {} submitting shop", status);
+        spdlog::error("Shop: network error submitting shop: HTTP {}, Qt error {}: {}",
+                      status,
+                      reply->error(),
+                      reply->errorString());
+        FailActiveJob();
+        return;
     }
 
     const QByteArray bytes = reply->readAll();
+    if (IsPoeSessionRejected(bytes)) {
+        RejectPoeSession("forum submission returned an authentication error page");
+        FailActiveJob();
+        return;
+    }
 
     // Errors can show up in a couple different places. So far, the easiest way to identify
     // them seems to be to look for an html tag with the "class" attribute set to

--- a/src/shop.h
+++ b/src/shop.h
@@ -77,6 +77,7 @@ signals:
     void StashesIndexed();
     void StatusUpdate(ProgramState state, const QString &status);
     void UserWarning(const QString &message);
+    void PoeSessionRejected();
 
 private:
     // One forum submission job (items-pipeline M2, D8/R2-1): its input is
@@ -138,6 +139,7 @@ private:
     void OnStashIndexReceived(
         const std::expected<poe::WebStashListWrapper, RateLimit::FetchError> &result);
     void OnStashIndexUpdated();
+    void RejectPoeSession(const QString &reason);
 
     void SubmitSingleShop();
     void SubmitNextShop(const QString &title, const QString &hash);

--- a/src/util/networkmanager.cpp
+++ b/src/util/networkmanager.cpp
@@ -73,6 +73,17 @@ NetworkManager::NetworkManager(QObject *parent)
     setCache(m_diskCache);
 }
 
+void NetworkManager::clearPoeSessionId()
+{
+    spdlog::debug("NetworkManager: clearing POESESSID");
+    QNetworkCookie cookie{POE_COOKIE_NAME, QByteArray{}};
+    cookie.setPath(POE_COOKIE_PATH);
+    cookie.setDomain(POE_COOKIE_DOMAIN);
+    if (!cookieJar()->deleteCookie(cookie)) {
+        spdlog::debug("NetworkManager: no POESESSID cookie was present");
+    }
+}
+
 void NetworkManager::setPoeSessionId(const QString &poesessid)
 {
     QString masked = poesessid;

--- a/src/util/networkmanager.h
+++ b/src/util/networkmanager.h
@@ -15,6 +15,7 @@ class NetworkManager : public QNetworkAccessManager
 public:
     explicit NetworkManager(QObject *parent = nullptr);
 
+    void clearPoeSessionId();
     void setPoeSessionId(const QString &poesessid);
     void setBearerToken(const QString &token);
 

--- a/tests/fakenetwork.h
+++ b/tests/fakenetwork.h
@@ -104,13 +104,17 @@ public:
 
     void resolve(size_t i, const QByteArray &body) { complete(i, RateLimit::FetchOutcome(body)); }
 
-    void reject(size_t i, RateLimit::FetchError::Kind kind, const QString &message = {})
+    void reject(size_t i,
+                RateLimit::FetchError::Kind kind,
+                const QString &message = {},
+                int http_status = 0)
     {
         const PendingFuture &pending = m_futures.at(i);
         RateLimit::FetchError error;
         error.kind = kind;
         error.endpoint = pending.endpoint;
         error.url = pending.request.url();
+        error.http_status = http_status;
         error.message = message;
         complete(i, RateLimit::FetchOutcome(std::unexpected(std::move(error))));
     }

--- a/tests/tst_shop.cpp
+++ b/tests/tst_shop.cpp
@@ -67,7 +67,10 @@ private slots:
     void settingAndClearingThreads();
     void threadsRoundTripThroughDatastore();
     void stashIndexFailureReleasesTheSubmitLock();
+    void stashIndex403RejectsPoeSession();
     void stashIndexSuccessProceedsToShopSubmission();
+    void editPage403RejectsPoeSession();
+    void shopPost403RejectsPoeSession();
     void continuationDoesNotRunAfterShopDestruction();
 
     // Items-pipeline M2, D8: the single-active-job foundation (stage 2
@@ -216,6 +219,24 @@ void ShopTest::stashIndexFailureReleasesTheSubmitLock()
     QCOMPARE(fixture.rateLimiter->futureCount(), size_t(2));
 }
 
+void ShopTest::stashIndex403RejectsPoeSession()
+{
+    ShopFixture fixture;
+    armForSubmission(fixture);
+    fixture.shop->SetAutoUpdate(true);
+    QSignalSpy rejected(fixture.shop.get(), &Shop::PoeSessionRejected);
+    QSignalSpy warnings(fixture.shop.get(), &Shop::UserWarning);
+
+    fixture.shop->SubmitShopToForum();
+    fixture.rateLimiter->reject(0, RateLimit::FetchError::Kind::Http, "HTTP status 403", 403);
+    drainEvents();
+
+    QCOMPARE(rejected.count(), 1);
+    QCOMPARE(warnings.count(), 1);
+    QVERIFY(!fixture.shop->auto_update());
+    QCOMPARE(fixture.networkManager->count(), 0);
+}
+
 void ShopTest::stashIndexSuccessProceedsToShopSubmission()
 {
     // The success path parses below the facade and carries on into the forum
@@ -243,6 +264,52 @@ void ShopTest::stashIndexSuccessProceedsToShopSubmission()
     // And the lock is still held while that submission is in flight.
     fixture.shop->SubmitShopToForum(true);
     QCOMPARE(fixture.rateLimiter->futureCount(), size_t(1));
+}
+
+void ShopTest::editPage403RejectsPoeSession()
+{
+    ShopFixture fixture;
+    armForSubmission(fixture);
+    fixture.shop->SetAutoUpdate(true);
+    QSignalSpy rejected(fixture.shop.get(), &Shop::PoeSessionRejected);
+
+    fixture.shop->SubmitShopToForum(true);
+    fixture.rateLimiter->resolve(0, kStashIndexJson);
+    drainEvents();
+    QCOMPARE(fixture.networkManager->count(), 1);
+
+    fixture.networkManager->sent(0).reply->finish({},
+                                                  403,
+                                                  QNetworkReply::ContentAccessDenied,
+                                                  QByteArray("Content Denied"));
+    drainEvents();
+
+    QCOMPARE(rejected.count(), 1);
+    QVERIFY(!fixture.shop->auto_update());
+    QCOMPARE(fixture.networkManager->count(), 1);
+}
+
+void ShopTest::shopPost403RejectsPoeSession()
+{
+    ShopFixture fixture;
+    armForSubmission(fixture);
+    fixture.shop->SetAutoUpdate(true);
+    QSignalSpy rejected(fixture.shop.get(), &Shop::PoeSessionRejected);
+
+    fixture.shop->SubmitShopToForum(true);
+    fixture.rateLimiter->resolve(0, kStashIndexJson);
+    drainEvents();
+    fixture.networkManager->sent(0).reply->finish({}, 200, QNetworkReply::NoError, kEditThreadPage);
+    QTRY_COMPARE_WITH_TIMEOUT(fixture.networkManager->count(), 2, 5000);
+
+    fixture.networkManager->sent(1).reply->finish({},
+                                                  403,
+                                                  QNetworkReply::ContentAccessDenied,
+                                                  QByteArray("Content Denied"));
+    drainEvents();
+
+    QCOMPARE(rejected.count(), 1);
+    QVERIFY(!fixture.shop->auto_update());
 }
 
 void ShopTest::continuationDoesNotRunAfterShopDestruction()


### PR DESCRIPTION
## Summary

- advance the prerelease version to 0.18.0-alpha.6
- treat HTTP 401/403 responses and recognized authentication-error pages in the forum-shop flow as a rejected POESESSID
- immediately clear the in-memory cookie and persisted setting, disable automatic forum updates, discard queued automatic submissions, and warn the user
- preserve normal OAuth-backed stash and character updates
- use the real HTTP status in the forum POST handler instead of interpreting Qt's NetworkError enum as a status code

## Motivation

In issue https://github.com/gerwaric/acquisition/issues/189, a user reported an account ban for third-party software after several attempted forum updates. Clearing POESESSID is a conservative response with narrow impact because it is used only by the forum-shop path.

## Verification

- full Qt 6.11.1 / MSVC 2022 debug build
- all 35 CTest cases pass
- focused coverage for rejection during the legacy stash-index request, edit-page GET, and forum POST
- git diff --check
- clang-format check on touched shop/application/test files