### PR TITLE
Two small fixes: BORDERLINE log level (F30) and buyout price formatting (#150)

### DIFF
--- a/docs/cleanup/findings.md
+++ b/docs/cleanup/findings.md
@@ -148,8 +148,9 @@ The F-numbers refer to the ledger below.
   `qScopeGuard` declared before `Application` in `main.cpp` so it runs
   after all threads are joined; keep it that way.
 - **F30 — BORDERLINE is not an error.** The frequent "policy is
-  BORDERLINE" rate-limit warnings during refreshes are normal saturation
-  pacing, not a failure signal (arguably worth downgrading from `warn`).
+  BORDERLINE" rate-limit messages during refreshes are normal saturation
+  pacing, not a failure signal (downgraded from `warn` to `info`,
+  August 2026).
 - **F31 — check acceptance criteria against non-goals.** A grep-shaped
   acceptance criterion once forced out a load-bearing guard the same
   spec's non-goals said to keep. Mechanical criteria are subordinate to

--- a/src/buyout.cpp
+++ b/src/buyout.cpp
@@ -103,7 +103,9 @@ BuyoutType Buyout::IndexAsBuyoutType(int index)
 QString Buyout::AsText() const
 {
     if (IsPriced()) {
-        return BuyoutTypeAsTag() + " " + QString::number(value) + " " + CurrencyAsTag();
+        // 'g' with wide precision: QString::number(double) defaults to six
+        // significant digits, turning large prices into scientific notation.
+        return BuyoutTypeAsTag() + " " + QString::number(value, 'g', 15) + " " + CurrencyAsTag();
     } else {
         return BuyoutTypeAsTag();
     }

--- a/src/ratelimit/ratelimitmanager.cpp
+++ b/src/ratelimit/ratelimitmanager.cpp
@@ -641,7 +641,7 @@ RateLimitManager::Observation RateLimitManager::RecordLandedReply(RateLimitedReq
     const Observation observation = Update(reply);
 
     if (m_policy->status() == RateLimit::Status::BORDERLINE) {
-        spdlog::warn("Rate limit policy '{}' is BORDERLINE and the next safe send is at {}",
+        spdlog::info("Rate limit policy '{}' is BORDERLINE and the next safe send is at {}",
                      m_policy->name(),
                      m_policy->GetNextSafeSend(m_history).toString());
     }

--- a/src/shop.cpp
+++ b/src/shop.cpp
@@ -213,7 +213,7 @@ QString Shop::SpoilerBuyout(const Buyout &bo)
     QString out = "";
     out += "[spoiler=\"" + bo.BuyoutTypeAsPrefix();
     if (bo.IsPriced()) {
-        out += " " + QString::number(bo.value) + " " + bo.CurrencyAsTag();
+        out += " " + QString::number(bo.value, 'g', 15) + " " + bo.CurrencyAsTag();
     }
     out += "\"]";
     return out;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1508,7 +1508,7 @@ void MainWindow::UpdateBuyoutWidgets(const Buyout &bo)
 
     if (bo.IsPriced()) {
         ui->buyoutCurrencyComboBox->setCurrentIndex(bo.currency.type);
-        ui->buyoutValueLineEdit->setText(QString::number(bo.value));
+        ui->buyoutValueLineEdit->setText(QString::number(bo.value, 'g', 15));
         if (!bo.IsGameSet()) {
             ui->buyoutCurrencyComboBox->setEnabled(true);
             ui->buyoutValueLineEdit->setEnabled(true);


### PR DESCRIPTION
Author note: Some low hanging fruit!

Two independent one-commit fixes:

**Downgrade the BORDERLINE pacing message from warn to info (F30)**

The findings register's F30 standing note records that the frequent "policy is BORDERLINE" messages during refreshes are normal saturation pacing, not a failure signal, and were "arguably worth downgrading from warn." This does that downgrade and updates the register note to match.

**Format buyout prices with enough digits to avoid scientific notation (fixes #150)**

`QString::number(double)` defaults to six significant digits, so large buyout values rendered as scientific notation (1234567 → 1.23457e+06) in the price column and tooltips (`Buyout::AsText`), the forum shop spoiler text, and the buyout edit box. All three sites now use `'g'` with 15 significant digits, which renders typical prices exactly with no trailing-zero noise.

Built and ran the full test suite (35/35 passing) with both changes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMh7nZndnFDht8mCFV7EAV