### PR TITLE
ci: upload native debug symbols to sentry for all three platforms

### DIFF
--- a/.github/actions/sentry-symbols/action.yml
+++ b/.github/actions/sentry-symbols/action.yml
@@ -1,0 +1,80 @@
+name: 'Upload debug symbols to Sentry'
+description: >
+  Installs a pinned sentry-cli and uploads native debug information files so
+  crash reports from released builds are symbolicated.
+
+inputs:
+  paths:
+    description: >
+      Whitespace-separated files or directories to upload. Always pass the
+      shipped binary alongside its debug file: Sentry matches the two by debug
+      ID (PDB GUID on Windows, GNU build ID on Linux, LC_UUID on macOS), and
+      the binary is what carries the unwind information.
+    required: true
+  org:
+    description: 'Sentry organization slug.'
+    required: true
+  project:
+    description: 'Sentry project slug.'
+    required: true
+  auth-token:
+    description: >
+      Sentry organization auth token. When empty the upload is skipped rather
+      than failed, so builds from forks (which cannot see repository secrets)
+      still succeed.
+    required: false
+    default: ''
+  include-sources:
+    description: >
+      Upload source bundles so stack traces show source context. This sends
+      the project source to Sentry; acquisition is GPL, so there is nothing to
+      protect, but set this to 'false' to opt out.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Upload debug information files
+      shell: bash
+      env:
+        SENTRY_ORG: ${{ inputs.org }}
+        SENTRY_PROJECT: ${{ inputs.project }}
+        SENTRY_AUTH_TOKEN: ${{ inputs.auth-token }}
+        DIF_PATHS: ${{ inputs.paths }}
+        INCLUDE_SOURCES: ${{ inputs.include-sources }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${SENTRY_AUTH_TOKEN}" ]; then
+          echo "SENTRY_AUTH_TOKEN is not set (fork build?); skipping symbol upload."
+          exit 0
+        fi
+        if [ -z "${SENTRY_ORG}" ]; then
+          echo "SENTRY_ORG is not set; skipping symbol upload."
+          exit 0
+        fi
+
+        # Pinned for the same reason innosetup is pinned in build-windows.yml:
+        # an unpinned download URL has silently served the wrong payload before.
+        SENTRY_CLI_VERSION=3.6.2
+        case "${RUNNER_OS}" in
+          Linux)   asset=sentry-cli-Linux-x86_64 ;;
+          macOS)   asset=sentry-cli-Darwin-universal ;;
+          Windows) asset=sentry-cli-Windows-x86_64.exe ;;
+          *) echo "Unsupported runner OS: ${RUNNER_OS}" >&2; exit 1 ;;
+        esac
+
+        cli="${RUNNER_TEMP}/${asset}"
+        curl -sSfL --retry 3 -o "${cli}" \
+          "https://downloads.sentry-cdn.com/sentry-cli/${SENTRY_CLI_VERSION}/${asset}"
+        chmod +x "${cli}"
+
+        args=(debug-files upload --wait)
+        if [ "${INCLUDE_SOURCES}" = "true" ]; then
+          args+=(--include-sources)
+        fi
+
+        # DIF_PATHS is deliberately unquoted: it is a whitespace-separated list.
+        # shellcheck disable=SC2086
+        "${cli}" "${args[@]}" ${DIF_PATHS}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -59,6 +59,17 @@ jobs:
         echo "version=$version"
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
+    # build/acquisition is stripped by a POST_BUILD step in CMakeLists.txt and
+    # carries the GNU build ID plus .eh_frame unwind data; acquisition.debug
+    # carries the DWARF. Sentry needs both, matched by build ID.
+    - name: Upload debug symbols to Sentry
+      uses: ./.github/actions/sentry-symbols
+      with:
+        paths: build/acquisition.debug build/acquisition
+        org: ${{ vars.SENTRY_ORG }}
+        project: acquisition
+        auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
     - name: Package AppImage
       env:
         QMAKE: ${{ env.QT_ROOT_DIR }}/bin/qmake
@@ -87,6 +98,37 @@ jobs:
         name: acquisition-${{ steps.version.outputs.version }}-x86_64.debug
         path: build/acquisition.debug
         retention-days: 30
+
+    # Only this workflow creates the Sentry release; the Windows and macOS
+    # workflows upload symbols for the same release and would otherwise race
+    # to create it three times over.
+    - name: Create Sentry release
+      if: startsWith(github.ref, 'refs/tags/v') && vars.SENTRY_ORG != ''
+      env:
+        SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+        SENTRY_PROJECT: acquisition
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      run: |
+        set -euo pipefail
+        if [ -z "${SENTRY_AUTH_TOKEN}" ]; then
+          echo "SENTRY_AUTH_TOKEN is not set; skipping Sentry release."
+          exit 0
+        fi
+
+        # Must match SENTRY_RELEASE in src/main.cpp: APP_NAME "@" APP_VERSION_STRING.
+        release="acquisition@${{ steps.version.outputs.version }}"
+
+        cli="${RUNNER_TEMP}/sentry-cli-Linux-x86_64"
+        curl -sSfL --retry 3 -o "${cli}" \
+          "https://downloads.sentry-cdn.com/sentry-cli/3.6.2/sentry-cli-Linux-x86_64"
+        chmod +x "${cli}"
+
+        "${cli}" releases new "${release}"
+        # Suspect commits need the Sentry GitHub integration; don't fail the
+        # release build if it isn't configured.
+        "${cli}" releases set-commits "${release}" --auto \
+          || echo "::warning::Could not associate commits (is the Sentry GitHub integration set up?)"
+        "${cli}" releases finalize "${release}"
 
     - name: Create draft release
       if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -57,6 +57,17 @@ jobs:
       run: |
         version=$(grep APP_VERSION_STRING build/version_defines.h | cut -d'"' -f2)
         echo "version=$version"
+
+        # The update checker parses APP_VERSION_STRING as the running version and
+        # compares it against github release tags (src/util/updatechecker.cpp),
+        # so a tag that disagrees with the build would tell every user to update
+        # to the version they are already running, on every check.
+        if [ "$GITHUB_REF_TYPE" = "tag" ] && [ "$GITHUB_REF_NAME" != "v$version" ]; then
+          echo "::error::Tag $GITHUB_REF_NAME does not match APP_VERSION_STRING $version"
+          echo "::error::Update app_version / app_version_suffix in CMakeLists.txt"
+          exit 1
+        fi
+
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
     # build/acquisition is stripped by a POST_BUILD step in CMakeLists.txt and

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -38,6 +38,17 @@ jobs:
       run: |
         version=$(grep APP_VERSION_STRING build/version_defines.h | cut -d'"' -f2)
         echo "version=$version"
+
+        # The update checker parses APP_VERSION_STRING as the running version and
+        # compares it against github release tags (src/util/updatechecker.cpp),
+        # so a tag that disagrees with the build would tell every user to update
+        # to the version they are already running, on every check.
+        if [ "$GITHUB_REF_TYPE" = "tag" ] && [ "$GITHUB_REF_NAME" != "v$version" ]; then
+          echo "::error::Tag $GITHUB_REF_NAME does not match APP_VERSION_STRING $version"
+          echo "::error::Update app_version / app_version_suffix in CMakeLists.txt"
+          exit 1
+        fi
+
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
     # The dSYM is produced by dsymutil in a POST_BUILD step in CMakeLists.txt.

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -40,6 +40,19 @@ jobs:
         echo "version=$version"
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
+    # The dSYM is produced by dsymutil in a POST_BUILD step in CMakeLists.txt.
+    # Uploading before macdeployqt is fine: install_name_tool rewrites load
+    # commands but leaves LC_UUID, which is what Sentry matches on.
+    - name: Upload debug symbols to Sentry
+      uses: ./.github/actions/sentry-symbols
+      with:
+        paths: >-
+          build/acquisition_${{ steps.version.outputs.version }}.dSYM
+          build/acquisition.app/Contents/MacOS/acquisition
+        org: ${{ vars.SENTRY_ORG }}
+        project: acquisition
+        auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
     - name: Package DMG
       run: |
         $QT_ROOT_DIR/bin/macdeployqt \

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -46,6 +46,26 @@ jobs:
     - name: Test
       run: ctest --test-dir build --output-on-failure
 
+    - name: Get version
+      id: version
+      run: |
+        $header = Get-Content "build\version_defines.h" -Raw
+        if ($header -notmatch '#define APP_VERSION_STRING\s+"([^"]+)"') {
+          throw "Could not read APP_VERSION_STRING from build\version_defines.h"
+        }
+        $version = $matches[1]
+
+        # The update checker parses APP_VERSION_STRING as the running version and
+        # compares it against github release tags (src/util/updatechecker.cpp),
+        # so a tag that disagrees with the build would tell every user to update
+        # to the version they are already running, on every check.
+        if ($env:GITHUB_REF_TYPE -eq 'tag' -and $env:GITHUB_REF_NAME -ne "v$version") {
+          Write-Host "::error::Tag $env:GITHUB_REF_NAME does not match APP_VERSION_STRING $version"
+          Write-Host "::error::Update app_version / app_version_suffix in CMakeLists.txt"
+          exit 1
+        }
+        echo "version=$version" >> $env:GITHUB_OUTPUT
+
     - name: Upload debug symbols to Sentry
       uses: ./.github/actions/sentry-symbols
       with:
@@ -91,15 +111,14 @@ jobs:
       run: |
         & ISCC.exe /DBUILD_DIR="build" /DDEPLOY_DIR="build\deploy" "installer.iss"
 
-    - name: Get version
-      id: version
+    - name: Name the pdb for distribution
       run: |
-        if ($env:GITHUB_REF -match '^refs/tags/v(.+)$') {
-          $version = $matches[1]
-        } else {
-          $version = "dev-$(git rev-parse --short HEAD)"
-        }
-        echo "version=$version" >> $env:GITHUB_OUTPUT
+        # Every release shipped its symbols as a plain 'acquisition.pdb', so two
+        # of them collide in a download folder and a stray copy cannot be traced
+        # back to a build. Copy rather than rename: the linker's own name is what
+        # the PE records, and local debuggers look the pdb up by that name.
+        Copy-Item "build\acquisition.pdb" `
+          "build\acquisition-${{ steps.version.outputs.version }}.pdb"
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v7
@@ -107,7 +126,7 @@ jobs:
         name: acquisition-installer-${{ steps.version.outputs.version }}
         path: |
           Output/*.exe
-          build/acquisition.pdb
+          build/acquisition-${{ steps.version.outputs.version }}.pdb
         retention-days: 30
 
     - name: Create draft release
@@ -116,7 +135,7 @@ jobs:
       with:
         files: |
           Output/Acquisition_setup_*.exe
-          build/acquisition.pdb
+          build/acquisition-${{ steps.version.outputs.version }}.pdb
         generate_release_notes: true
         draft: true
         prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -46,6 +46,14 @@ jobs:
     - name: Test
       run: ctest --test-dir build --output-on-failure
 
+    - name: Upload debug symbols to Sentry
+      uses: ./.github/actions/sentry-symbols
+      with:
+        paths: build/acquisition.pdb build/acquisition.exe
+        org: ${{ vars.SENTRY_ORG }}
+        project: acquisition
+        auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
     - name: Prepare deployment
       run: |
         $deploy = "build\deploy"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include <QTimer>
 
 #include <clocale>
+#include <string_view>
 
 #include <sentry.h>
 
@@ -33,6 +34,21 @@ constexpr const char *SENTRY_RELEASE = APP_NAME "@" APP_VERSION_STRING;
 constexpr const char *SENTRY_DSN
     = "https://89d30fa945c751603c0dfdde2c574497@o4509396161855488.ingest.us.sentry.io/"
       "4510597980618752";
+
+// Keep pre-release and local crashes out of the stable release's numbers in
+// sentry, which otherwise reports every build in one bucket and makes the
+// crash-free rate of a release meaningless.
+//
+// A version string is a pre-release exactly when it carries a suffix, and
+// CMakeLists.txt rejects any 'app_version_suffix' that does not start with a
+// hyphen, so a hyphen here is a reliable marker.
+#ifdef QT_DEBUG
+constexpr const char *SENTRY_ENVIRONMENT = "development";
+#else
+constexpr const char *SENTRY_ENVIRONMENT = std::string_view(APP_VERSION_STRING).contains('-')
+                                               ? "pre-release"
+                                               : "production";
+#endif
 
 #ifdef QT_DEBUG
 constexpr const char *DEFAULT_LOGGING_LEVEL = "debug";
@@ -96,11 +112,22 @@ int main(int argc, char *argv[])
     sentry_options_set_handler_path(options, handlerPath.constData());
     sentry_options_set_database_path(options, sentryPath.constData());
     sentry_options_set_release(options, SENTRY_RELEASE);
+    sentry_options_set_environment(options, SENTRY_ENVIRONMENT);
     sentry_options_set_enable_logs(options, 1);
     sentry_init(options);
 
     // Make sure sentry closes when the program terminates.
     auto sentryClose = qScopeGuard([] { sentry_close(); });
+
+    // Tag the Qt version acquisition was built against and the one it actually
+    // loaded. A mismatch between the two - and the related MSVC runtime problem
+    // that checkMicrosoftRuntime() looks for below - is a recurring source of
+    // crashes, so tagging makes that whole family filterable in sentry instead
+    // of needing a read of every stack trace. These go on the global scope
+    // immediately after sentry_init() so that crashpad picks them up for native
+    // crashes as well as for events.
+    sentry_set_tag("qt.build", QT_VERSION_STR);
+    sentry_set_tag("qt.runtime", qVersion());
 
     // Setup logging.
     const QString logPath(appDataDir.filePath("log.txt"));


### PR DESCRIPTION
Crash reports from released builds arrived unsymbolicated: the debug
information files were only ever attached to GitHub releases, never sent to
Sentry. Each platform already produced what Sentry needs, so the missing
piece was the upload itself.

## Symbol upload (all three platforms)

A composite action installs a pinned `sentry-cli` and uploads the shipped
binary alongside its debug file:

| Platform | Uploaded |
|---|---|
| Windows | `acquisition.pdb` + `acquisition.exe` |
| Linux | `acquisition.debug` + `acquisition` |
| macOS | `acquisition_<version>.dSYM` + the bundle binary |

Both halves are needed: Sentry pairs them by debug ID, and the binary carries
the unwind data (`.pdata` on Windows, `.eh_frame` on Linux) that the debug
file lacks. Uploads skip rather than fail when the token or org is absent, so
fork builds still pass.

The Sentry release is created from the Linux workflow alone — all three
running it would race to create the same release three times.

## Sentry environment and Qt tags

Every build reported into one bucket, making a release's crash-free rate
meaningless. The environment is now derived from the version suffix that
`CMakeLists.txt` already validates (`development` / `pre-release` /
`production`).

Also tags the Qt version built against versus the one actually loaded. That
mismatch, and the related MSVC runtime problem `checkMicrosoftRuntime()`
looks for, is a recurring crash source; tagging makes the whole family
filterable. Tags are set immediately after `sentry_init()` so crashpad picks
them up for native crashes too.

## Release asset hygiene

Every release shipped its symbols as a plain `acquisition.pdb`, so two
downloads collide in a browser's download folder and a stray copy can't be
traced back to a build — this cost real time diagnosing a recent crash. The
release asset is now versioned, as the AppImage and DMG already are.

Windows now takes its version from `APP_VERSION_STRING` rather than the git
tag, matching the other two workflows and everything else the build derives
from. A guard then asserts tag and build agree: `updatechecker.cpp` parses
`APP_VERSION_STRING` as the running version and compares it against release
tags, so a build tagged ahead of `CMakeLists.txt` would tell every user to
update to the version they are already running, on every check.

## Configuration required

Repository variable `SENTRY_ORG` and secret `SENTRY_AUTH_TOKEN` — both
already set.

## Testing

YAML validated for all four files; tag guard simulated (matching tag passes,
mismatched tag fails, branch builds unaffected); the Windows version regex
verified against a real generated `version_defines.h`. Release build and the
full 39-test suite pass locally. The PowerShell blocks are unexecuted —
`pwsh` isn't available locally — so a `workflow_dispatch` run is the real
proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
