### PR TITLE
fix: stop the layout recursion and the fatal login abort

### DIFF
--- a/src/ui/logindialog.cpp
+++ b/src/ui/logindialog.cpp
@@ -311,6 +311,17 @@ void LoginDialog::OnLoginButtonClicked()
 
     const QString realm = ui->realmComboBox->currentText();
     const QString league = ui->leagueComboBox->currentText();
+
+    // Refuse the login here rather than letting it reach UserSession, whose
+    // constructor treats an unset league as fatal. That check has to stay
+    // upstream of Application::InitUserSession(): once a session exists it
+    // cannot be replaced (the shutdown invariant in network-redesign.md), so a
+    // failure after construction leaves no way back to this dialog.
+    if (league.isEmpty()) {
+        DisplayError("Please select a league before logging in.");
+        return;
+    }
+
     m_settings.setValue("realm", realm);
     m_settings.setValue("league", league);
 
@@ -474,7 +485,13 @@ void LoginDialog::DisplayError(const QString &error)
     spdlog::error("LoginDialog: {}", error);
     ui->errorLabel->setText(error);
     ui->errorLabel->show();
+
+    // OnLoginButtonClicked() disables the button while a login is in flight.
+    // Restoring the label without re-enabling it left the dialog looking ready
+    // but inert after any failed attempt. Callers that want it to stay
+    // disabled (the league request errors) disable it again after this call.
     ui->loginButton->setText("Login");
+    ui->loginButton->setEnabled(true);
 }
 
 bool LoginDialog::event(QEvent *e)

--- a/src/ui/verticalscrollarea.cpp
+++ b/src/ui/verticalscrollarea.cpp
@@ -5,6 +5,7 @@
 #include "ui/verticalscrollarea.h"
 
 #include <QEvent>
+#include <QScopedValueRollback>
 #include <QScrollBar>
 
 VerticalScrollArea::VerticalScrollArea(QWidget *parent)
@@ -18,8 +19,29 @@ VerticalScrollArea::VerticalScrollArea(QWidget *parent)
 bool VerticalScrollArea::eventFilter(QObject *o, QEvent *e)
 {
     // This works because QScrollArea::setWidget installs an eventFilter on the widget
-    if (o && o == widget() && e->type() == QEvent::Resize) {
-        setMinimumWidth(widget()->minimumSizeHint().width() + verticalScrollBar()->width() + 6);
+    if (!m_adjusting_width && o && o == widget() && e->type() == QEvent::Resize) {
+        // Setting a minimum width here relays the scroll area out, which
+        // resizes the child widget, which delivers another Resize event back to
+        // this filter. In 0.18.3-beta.1 that fed back on itself ~429 times and
+        // exhausted the stack: the crash dump shows this filter, QLayout::activate
+        // and QCoreApplicationPrivate::sendThroughObjectEventFilters repeating.
+        //
+        // The loop only terminates on its own if the computed width settles, and
+        // it need not: the search form's content uses heightForWidth (FlowLayout),
+        // so height depends on width, the vertical scroll bar's visibility depends
+        // on height under ScrollBarAsNeeded, and the width computed below depends
+        // on the scroll bar again. Guard the re-entry rather than assume the
+        // arithmetic converges.
+        QScopedValueRollback<bool> guard(m_adjusting_width, true);
+
+        // sizeHint() rather than width(): a hidden scroll bar keeps whatever
+        // width it was last laid out to, which makes this term depend on
+        // visibility for no useful reason.
+        const int width = widget()->minimumSizeHint().width()
+                          + verticalScrollBar()->sizeHint().width() + 6;
+        if (width != minimumWidth()) {
+            setMinimumWidth(width);
+        }
     }
     return QScrollArea::eventFilter(o, e);
 }

--- a/src/ui/verticalscrollarea.h
+++ b/src/ui/verticalscrollarea.h
@@ -15,4 +15,9 @@ class VerticalScrollArea : public QScrollArea
 public:
     explicit VerticalScrollArea(QWidget *parent = 0);
     virtual bool eventFilter(QObject *o, QEvent *e);
+
+private:
+    // Guards against eventFilter() re-entering itself through the relayout its
+    // own setMinimumWidth() triggers. See the comment in eventFilter().
+    bool m_adjusting_width = false;
 };


### PR DESCRIPTION
Fixes both crashes currently reported in Sentry, diagnosed from their
minidumps.

## Stack overflow in `VerticalScrollArea` (0.18.3-beta.1)

`STACK_OVERFLOW` (0xC00000FD) on the main thread. The dump shows a
twelve-frame cycle repeated 429 times, consuming the entire 1 MB stack:
`VerticalScrollArea::eventFilter` (which tail-jumps into
`QScrollArea::eventFilter`, so it leaves no frame of its own),
`QLayout::activate`, `QApplication::notify`, and
`QCoreApplicationPrivate::sendThroughObjectEventFilters`, threaded with
`heightForWidth` vtable entries.

Setting a minimum width from a `Resize` handler relays the scroll area out,
resizing the child widget, delivering another `Resize` back to the filter.
That terminates only if the computed width settles, and nothing guarantees it
does: the search form uses `heightForWidth` (`FlowLayout`), so height depends
on width, scroll bar visibility depends on height under `ScrollBarAsNeeded`,
and the computed width depends on the scroll bar again.

The filter now guards re-entry, skips the write when the value is unchanged,
and asks the scroll bar for its `sizeHint()` rather than its current width.
The scroll bar policy is deliberately unchanged — pinning the bar visible
would break one edge of the cycle but would not bound the recursion if the
content later grew a width-dependent minimum width.

## Fatal abort on login with no league (0.18.2)

Not a fault at all. `FAIL_FAST_EXCEPTION` (0x40000015) whose fault address is
crashpad's own `DumpAndCrash`; the live stack runs from
`LoginDialog::OnLoginButtonClicked` through `Application::OnLogin` and
`InitUserSession` into `UserSession`'s constructor, which calls `FatalError`
because the league setting is empty. Pressing Login without a league kills the
application. Reported by a user in the field, and still occurring.

The league is now checked in the dialog. The check must stay upstream of
`InitUserSession()`: once `m_session` exists it cannot be replaced (the
shutdown invariant in `network-redesign.md`), so failing after construction
would leave no way back to the dialog. The `FatalError` calls remain as
backstops. The account setting needs no equivalent check — it comes from the
OAuth token, and `LoginWithOAuth()` already reports the unauthenticated cases.

Also re-enables the login button in `DisplayError()`. `OnLoginButtonClicked()`
disables it while a login is in flight and `DisplayError()` restored only its
text, so every failed attempt left the dialog looking ready but inert.

## Testing

Release build clean, 39/39 tests pass. A standalone Qt harness driving 60
resize cycles through a real `VerticalScrollArea` + `FlowLayout` confirms the
new code converges in one iteration and stays stable.

**The harness does not reproduce the original loop** — the unfixed code
survives it too, because the offscreen platform does not lay scroll bars out
realistically. It shows the new code terminates; it does not show the fix was
necessary. Confirmation needs a Windows build, which is why a
`workflow_dispatch` Windows artifact should be exercised before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
