### PR TITLE
Prepare 0.18.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .qtcreator/
 
+# Claude Code writes per-developer permission state here; the rest of
+# .claude/ is shared project config and should stay tracked.
+.claude/settings.local.json
+
 # Visual Studio and Qt Creator 13.0 puts builds here.
 /build/
 /out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,9 @@
 ## Build And Run
 - Read `BUILD.md` before changing build, packaging, or platform setup.
 - Configure and build with `cmake -S . -B build` and `cmake --build build`.
-- CMake requires Qt 6.11+ and the Qt Network Authorization module. Linux also requires OpenSSL.
+- CMake requires Qt 6.11+, the Qt Network Authorization module, and the private Qt Gui module that the fetched QXlsx dependency links against. Linux also requires OpenSSL.
+- A distribution's Qt packages often ship neither of those modules, so a bare `cmake -S . -B build` can pick up a system Qt and fail in `build/_deps/qxlsx-src` with `Failed to find required Qt component "GuiPrivate"`. Point CMake at an official Qt kit instead: `cmake -S . -B build -DCMAKE_PREFIX_PATH=<qt-install>/6.11.1/<compiler>`.
+- If `build/` already holds Qt Creator kit trees (`build/Desktop_Qt_6_11_1_Release` and similar), build and test in one of those rather than configuring a second tree at `build/` itself.
 - Run locally with `./build/acquisition --data-dir /tmp/acq-data` to avoid touching a user's real Acquisition data.
 - Run the checked-in Qt Test suite with `ctest --test-dir build --output-on-failure` after building.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ project(acquisition
 include(CTest)
 
 # Use this to define pre-releases
-set(app_version_suffix "-beta.1")
+set(app_version_suffix "")
 
 # Variables used in version_defines.h and platforn-specific files and properties.
 set(app_name            "${CMAKE_PROJECT_NAME}")


### PR DESCRIPTION
Prepares the `v0.18.3` tag, plus two pieces of housekeeping that were in the
tree alongside it.

### Clear the pre-release suffix

`app_version_suffix` goes from `"-beta.1"` to `""`, so `APP_VERSION_STRING`
becomes `0.18.3`. Everything downstream derives from the generated
`version_defines.h`, so this is the only edit needed: `installer.iss` takes
both `AppVersion` and `OutputBaseFilename` from it, and all three workflows
read it for the tag guard and artifact names.

One side effect worth calling out: `SENTRY_ENVIRONMENT` (`src/main.cpp`)
treats a hyphen in the version as the pre-release marker, so this build
reports as `production` rather than `pre-release`. That is the intent for a
final release, and it is the first build to take that branch.

0.18.3-beta.1 is superseded rather than followed by a beta.2 — the two crash
fixes it was cut to test (#203) came back clean on Windows.

### Housekeeping

- `AGENTS.md`: a bare `cmake -S . -B build` can resolve to a distribution Qt
  that ships neither `Qt6NetworkAuth` nor `Qt6GuiPrivate`. The fetched QXlsx
  dependency requires the latter, so configuration fails inside `qxlsx-src`
  rather than anywhere that names the real problem. Documents the
  `CMAKE_PREFIX_PATH` this needs, and notes the Qt Creator kit trees under
  `build/`.
- `.gitignore`: ignore `.claude/settings.local.json`, which holds a
  machine-specific permission allowlist. It was previously covered only by a
  personal global gitignore, so it showed up as untracked noise for anyone
  else. Only the `.local` file — shared `.claude/` config stays tracked,
  matching the tracked `CLAUDE.md` and `AGENTS.md`.

### Verification

`cmake --build` clean and 39/39 tests passing against Qt 6.11.1; confirmed
`version_defines.h` regenerates as `0.18.3` rather than assuming the CMake
edit propagated.

### After merge

Tag `master`, not this branch — if this is squash-merged these commits will
not exist on `master`, and the release would point outside its history. The
tag guard compares the tag against `APP_VERSION_STRING` and so cannot catch
that particular mistake.
