### PR TITLE
docs: index the Rust spike from the documentation map and ADR 0003

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,14 @@ when this map and a header disagree, the header wins.
   Exploration lives on the `redesign` branch in `docs/redesign/`;
   until the ADR is accepted, the frozen specs above remain full
   authority and `master` work continues normally.
+- `../spikes/rust-playground/` (branch `spikes/rust-playground`) — the
+  Rust daemon/CLI spike feeding ADR 0003: `CONTEXT.md` is its agent
+  working memory (invariants, decisions, open topics) and its
+  `README.md` explains the mock-by-default and `ACQ_GGG=1` modes.
+  The spike's network cleanup (N0–N6) closed August 22, 2026;
+  `NETWORK-CLEANUP.md` is the short closed record. Ground-truth
+  claims the spike established (N31–N33) live in
+  `design/network-ground-truth.md`, not in the spike.
 - `cleanup/findings.md` — project-wide register of design/correctness
   findings (F1, F2, …): open findings, standing constraints, and a
   resolved ledger. The `cleanup/` path is historical — the register

--- a/docs/adr/0003-rewrite-vs-evolve.md
+++ b/docs/adr/0003-rewrite-vs-evolve.md
@@ -89,6 +89,10 @@ recorded in `docs/redesign/README.md` on the `redesign` branch.
 ## Follow-Up
 
 - Living exploration: `docs/redesign/` on the `redesign` branch.
+- Rust rewrite spike: `spikes/rust-playground/` on the
+  `spikes/rust-playground` branch (daemon + CLI, header-driven rate
+  limiter, OAuth under the existing registration); its `CONTEXT.md`
+  holds the decisions that spike has settled.
 - Control-plane contract input: PR #192 and
   `docs/design/local-control.md` on its branch.
 - Predecessor decisions: ADR 0001 (superseded), ADR 0002 (accepted;


### PR DESCRIPTION
Adds a `docs/README.md` entry and an ADR 0003 follow-up bullet pointing at `spikes/rust-playground/` on its branch. ADR 0003 previously pointed only at the `redesign` branch. Docs only; the spike's network cleanup (N0–N6) closed August 22, 2026.

`docs/design/network-ground-truth.md` was verified byte-identical between master and the spike branch (N31–N33 were already promoted), so nothing else needed to move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HS3CttMCdjcibfpjcxDeAz