### PR TITLE
fix(build): define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR for the whole build (0.18.4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.24)
 # tags on github are prefixed with a 'v'.
 
 project(acquisition
-    VERSION 0.18.3
+    VERSION 0.18.4
     DESCRIPTION "Stash and forum shop management for Path of Exile (TM)"
     HOMEPAGE_URL "https://github.com/gerwaric/acquisition"
     LANGUAGES CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,36 @@ else()
 endif()
 
 #------------------------------------------------------
+# MSVC runtime compatibility
+#------------------------------------------------------
+
+# MSVC 14.38 (VS 2022 17.8) made std::mutex's constructor constexpr, which
+# leaves the mutex's storage zero-initialized instead of set up by
+# _Mtx_init_in_situ. An older msvcp140.dll on the user's machine does not
+# understand that representation, and its mtx_do_lock dereferences a null
+# handle: an access violation reading 0x0 on the process's very first lock.
+# Acquisition hit this in the wild on 0.18.3 (a Windows 10 box whose system
+# CRT dated from February 2021), crashing inside spdlog's registry mutex
+# before logging::init() had returned.
+#
+# _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR restores the old non-constexpr
+# constructor, so the binary works against any 14.x runtime rather than
+# requiring users to have a current redistributable.
+#
+# This MUST be global, and MUST stay ahead of the FetchContent block below.
+# std::mutex's constructor is inline, so a mutex inside an inline function or
+# a header-only library (spdlog's registry singleton, for one) is emitted as a
+# COMDAT by every translation unit that uses it. Defining the macro for only
+# some targets makes those definitions disagree and the linker keeps whichever
+# one it likes - an ODR violation that reintroduces exactly this crash. The
+# fetched dependencies are compiled into the same binaries, so they need it
+# too; add_compile_definitions() applies to C as well as C++, which is what
+# sentry-native and crashpad want.
+add_compile_definitions(
+    $<$<OR:$<C_COMPILER_ID:MSVC>,$<CXX_COMPILER_ID:MSVC>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
+)
+
+#------------------------------------------------------
 # Sanitizers (test/CI only)
 #------------------------------------------------------
 
@@ -696,7 +726,6 @@ if(WIN32)
     target_compile_options(acquisition_core PRIVATE
         $<$<CXX_COMPILER_ID:MSVC>:/W4>
         $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
-        $<$<CXX_COMPILER_ID:MSVC>:/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
         $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<NOT:$<CONFIG:Debug>>>:/Zi>
     )
     target_link_options(acquisition PRIVATE

--- a/docs/cleanup/findings.md
+++ b/docs/cleanup/findings.md
@@ -185,7 +185,7 @@ only by `LoginDialog`. Fix shape: surface refresh failure to the UI
 and add an `oauth_rejected` de-arming path symmetric with the
 POESESSID one.
 
-### F78. `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` was defined for only one target — Confirmed; fix landed, Windows verification pending
+### F78. `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` was defined for only one target — Confirmed; fix landed and verified on Windows
 
 Found August 22, 2026, from a Sentry crash on 0.18.3
 (`acquisition.sentry.io/issues/7687078638`, two events, one Windows 10
@@ -222,12 +222,22 @@ Fix: the macro is now a global `add_compile_definitions()` in
 `CMakeLists.txt`, placed ahead of the `FetchContent` block so the
 fetched dependencies get it too, and removed from the per-target list.
 
-**Verification is still owed.** The reproduction is Windows-only and
-needs an old CRT; Linux configure/build/`ctest` (39/39) only proves
-nothing regressed. Confirm on a Windows build before treating this as
-closed.
+Verified on Windows (August 22, 2026, MSVC 14.51 / Qt 6.11.1, fresh
+Release tree): every one of the 55 compiled targets — app, core,
+filters, all tests, spdlog, QCoro, QXlsx, sentry, crashpad — carries
+the macro in its generated project, and none is without it;
+`dumpbin /imports acquisition.exe` shows `_Mtx_init_in_situ` imported
+from MSVCP140.dll, i.e. the runtime-initialized constructor that an old
+CRT understands rather than the constexpr zero-init; `ctest` 39/39; the
+app launches and runs past `logging::init`. Not reproduced against an
+actual 14.28 `msvcp140.dll` — the workstation has a current CRT — so
+the closing evidence is the import, not a crash-then-no-crash.
 
-Not fixed here, and still open:
+Not fixed here, and left open by decision (Tom, August 22, 2026): the
+stray-DLL check below exists because users once copied CRT DLLs into
+the Acquisition folder themselves, so it is guarding a real historical
+failure mode and should not be removed to make room for app-local
+deployment.
 
 - `installer.iss` leaves the redistributable an unchecked-able Task,
   so a user can still decline it. With the macro global this is no

--- a/docs/cleanup/findings.md
+++ b/docs/cleanup/findings.md
@@ -185,6 +185,61 @@ only by `LoginDialog`. Fix shape: surface refresh failure to the UI
 and add an `oauth_rejected` de-arming path symmetric with the
 POESESSID one.
 
+### F78. `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` was defined for only one target — Confirmed; fix landed, Windows verification pending
+
+Found August 22, 2026, from a Sentry crash on 0.18.3
+(`acquisition.sentry.io/issues/7687078638`, two events, one Windows 10
+19044 machine). `EXCEPTION_ACCESS_VIOLATION_READ / 0x0` inside
+`mtx_do_lock` (MSVCP140.dll), reached from `main` ->
+`logging::init` (`src/util/logging.cpp:78`) ->
+`spdlog::set_default_logger` -> `registry::set_default_logger`
+(`registry-inl.h`) -> `std::lock_guard`. The process died on its very
+first `std::mutex` lock, before `logging::init` returned.
+
+Mechanism: MSVC 14.38 (VS 2022 17.8) made `std::mutex`'s constructor
+`constexpr`, so the mutex's storage is constant-initialized to zero
+instead of being set up by `_Mtx_init_in_situ`. An older
+`msvcp140.dll` does not understand that representation and its
+`mtx_do_lock` dereferences a null handle. The crash event's debug
+images confirm it: `acquisition.exe` built 2026-08-20 against a
+`C:\Windows\SYSTEM32\MSVCP140.dll` built 2021-02-11 (~14.28, the
+VS 2019 redistributable). The bundled `vc_redist.x64.exe` had never
+run or had failed; `installer.iss` makes it an optional Task.
+
+`_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` was already in the build, but
+as a `PRIVATE` `target_compile_options` entry on `acquisition_core`
+alone. `src/main.cpp` (the `acquisition` target), `acquisition_filters`,
+every test target, and all fetched dependencies compiled without it.
+`std::mutex`'s constructor is inline, so a mutex inside an inline
+function or a header-only library — spdlog's `registry` singleton is
+exactly that — is emitted as a COMDAT by every translation unit that
+uses it. Mixing macro and non-macro TUs makes those definitions
+disagree and the linker keeps one arbitrarily: an ODR violation whose
+observable symptom is this crash. Partial coverage was therefore worse
+than none, because it read as protection.
+
+Fix: the macro is now a global `add_compile_definitions()` in
+`CMakeLists.txt`, placed ahead of the `FetchContent` block so the
+fetched dependencies get it too, and removed from the per-target list.
+
+**Verification is still owed.** The reproduction is Windows-only and
+needs an old CRT; Linux configure/build/`ctest` (39/39) only proves
+nothing regressed. Confirm on a Windows build before treating this as
+closed.
+
+Not fixed here, and still open:
+
+- `installer.iss` leaves the redistributable an unchecked-able Task,
+  so a user can still decline it. With the macro global this is no
+  longer fatal, but it should be forced.
+- `checkMicrosoftRuntime()` runs at `src/main.cpp:164`, *after*
+  `logging::init` at `:134`, so it can never fire for a crash in the
+  CRT's first lock. It also only looks for stray DLLs beside the exe
+  (`src/util/checkmsvc.cpp`) and never checks the system CRT's
+  version, which was the actual fault here.
+- Shipping the CRT DLLs app-local would conflict with that same
+  check, which aborts when it finds `msvcp140.dll` next to the exe.
+
 ## Standing constraints and lessons
 
 Rules distilled from resolved findings that remain binding on future work.


### PR DESCRIPTION
## Summary

Fixes the 0.18.3 startup crash reported by Sentry (issue 7687078638): `EXCEPTION_ACCESS_VIOLATION_READ / 0x0` in `mtx_do_lock` (MSVCP140.dll), reached from `main` -> `logging::init` -> `spdlog::set_default_logger`. The process died on its very first `std::mutex` lock.

**Mechanism.** MSVC 14.38+ made `std::mutex`'s constructor `constexpr`, so the mutex is zero-initialized instead of set up by `_Mtx_init_in_situ`. An older system `msvcp140.dll` (the crashing machine's was from Feb 2021, ~14.28) dereferences a null handle on that representation. `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` was already in the build, but only `PRIVATE` on `acquisition_core`. Since the constructor is inline and emitted as a COMDAT per TU, mixing macro and non-macro TUs (main.cpp, filters, tests, spdlog and every other fetched dep) is an ODR violation and the linker kept the constexpr version.

**Fix.** The macro is now a global `add_compile_definitions()` placed ahead of the `FetchContent` block, and removed from the per-target options. Recorded as F78 in `docs/cleanup/findings.md`.

Also bumps the version to **0.18.4**, since master is protected and the bump has to ride in the PR.

## Verification

- Linux: configure/build/ctest 39/39 (no regression).
- Windows (MSVC 14.51 / Qt 6.11.1, fresh Release tree):
  - all 55 compiled targets — app, core, filters, every test, spdlog, QCoro, QXlsx, sentry, crashpad — carry the macro in their generated projects; none without it
  - `dumpbin /imports acquisition.exe` shows `_Mtx_init_in_situ` imported from MSVCP140.dll, i.e. the runtime-initialized constructor that an old CRT understands
  - ctest 39/39
  - the app launches and runs past `logging::init`
- Not reproduced against an actual 14.28 `msvcp140.dll` (the workstation has a current CRT); the closing evidence is the import analysis.

## Deliberately left open (see F78)

- `installer.iss` still lets users decline the VC++ redistributable.
- `checkMicrosoftRuntime()` runs after `logging::init` and only checks for stray DLLs beside the exe — kept as-is because users once copied CRT DLLs into the install folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
