### PR TITLE
ci: EXPERIMENT — does an if:-skipped job satisfy the branch ruleset?

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,8 +18,38 @@ permissions:
   security-events: write
 
 jobs:
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.f.outputs.code }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: f
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          files=$(git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}")
+          echo "--- changed ---"; echo "$files"
+          # EXPERIMENT ONLY: .github/workflows/ is in the skip set so this PR skips itself.
+          if echo "$files" | grep -qvE '^(docs/|\.github/workflows/)|\.md$'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   analyze:
     name: Analyze C++
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -32,8 +32,38 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.f.outputs.code }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: f
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          files=$(git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}")
+          echo "--- changed ---"; echo "$files"
+          # EXPERIMENT ONLY: .github/workflows/ is in the skip set so this PR skips itself.
+          if echo "$files" | grep -qvE '^(docs/|\.github/workflows/)|\.md$'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   asan-lsan:
     name: ASan + LSan (integration runner)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
**Draft experiment — do not merge as-is.**

Tests whether skipping the required analysis jobs on docs-only PRs leaves the PR mergeable under the `Protect default branch` ruleset.

The skip set temporarily includes `.github/workflows/` so this PR skips its own analysis. If the experiment succeeds, that entry must be removed before merge.

Expected: `Analyze C++` and `ASan + LSan (integration runner)` report `skipped` (counts as success for required checks). Open question: whether the `CodeQL` check run from the github-advanced-security app — the `code_scanning` ruleset rule — appears at all when no analysis is uploaded.

Observe with:
```
gh api repos/gerwaric/acquisition/commits/$(gh pr view <N> --json headRefOid --jq .headRefOid)/check-runs
gh pr view <N> --json mergeable,mergeStateStatus
```