### PR TITLE
docs(ground-truth): N34 — a 401 carries no rate-limit headers; Q11

### DIFF
--- a/docs/design/network-ground-truth.md
+++ b/docs/design/network-ground-truth.md
@@ -595,6 +595,35 @@ endpoint is unlimited. A design that owns token traffic should track
 `token-request-limit` like any other policy — the headers parse
 identically.
 
+### Live-testing claims (August 24, 2026)
+
+Observed while soaking the Rust daemon against the live API on branch
+`spikes/rust-playground`; the run is recorded as rung 8 in that branch's
+`LIVE-TESTING.md`. Journal and daemon log retained in that branch's
+`runs/2026-08-23-r8/`.
+
+**N34. A 401 from an expired access token carries no rate-limit headers
+at all — not the policy, not the rules, not the state.** [OBSERVED —
+Confirmed August 23, 2026]
+Three GET `/character` requests with an expired bearer token, ten
+minutes apart, each returned `401 Unauthorized` with body
+`{"error":"invalid_token","error_description":"The access token provided
+is invalid or has expired"}` and an empty header set — the send journal
+recorded `rate: {}` for all three. The next request after a refresh
+returned the usual `character-list-request-limit` headers, so the route
+itself was unaffected.
+
+Two consequences. A limiter that maintains its window state from
+response headers learns nothing from a 401 and must carry its own
+accounting forward across one, rather than treating the absent headers
+as a cleared window. And by N27 the invalid-request budget includes
+every 4xx, so a 401 spends that budget against an undocumented
+threshold while returning nothing that would let a client detect the
+cost — which is what makes a timed stream of 401s (a daemon that
+believes an expired token is still valid) more dangerous than its
+request count suggests. Whether GGG also counts a 401 against the
+route's own policy counter is Q11.
+
 ## Open questions
 
 - **Q1. HEAD sanction verbatim. RESOLVED July 18, 2026** — Tom
@@ -683,6 +712,17 @@ identically.
   design side — decide whether the redesign *coordinates* legacy and
   forum traffic with API traffic (they share the IP, hence layer 1)
   or merely tolerates them as-is.
+
+- **Q11. Does a 401 count against the route's policy counter?** —
+  N34 establishes that a 401 returns no rate-limit headers, so the
+  question cannot be answered from the failing response itself. The
+  August 23 observation is inconclusive: the first successful request
+  after the three 401s came 600 s later, outside the 300 s window, and
+  reported `1:300:0` — consistent with either answer. Resolvable
+  cheaply the next time a 401 occurs by issuing one valid request
+  inside the shorter window and reading its state, but not worth
+  provoking deliberately; N27's invalid-request budget makes 401s
+  costly independently of the answer.
 
 ---
 


### PR DESCRIPTION
Adds one observed claim and one open question to `docs/design/network-ground-truth.md`. Docs only — no code changes.

## N34 — a 401 carries no rate-limit headers at all

Observed during the rung-8 soak of the Rust daemon on `spikes/rust-playground`. Three `GET /character` requests with an expired bearer token, ten minutes apart, each returned `401 Unauthorized` with an empty header set — the send journal recorded `rate: {}` for all three. The first request after the token refresh carried the usual `character-list-request-limit` headers, so the route itself was unaffected.

Two consequences are recorded with the claim:

- A limiter that maintains window state from response headers **learns nothing from a 401**, and must carry its own accounting forward across one rather than reading the absent headers as a cleared window.
- By **N27**, the invalid-request budget includes every 4xx. So a 401 spends that undocumented budget while returning nothing that would let a client detect the cost. That is what makes a *timed stream* of 401s — a daemon that believes an expired token is still valid — more dangerous than its request count suggests.

That second point is the reason this is a safety claim rather than a header curiosity.

## Q11 — does a 401 also count against the route's policy counter?

The run could not settle it. N34 means the failing response itself can never answer the question, and the first valid request afterward came 600 s later — outside the 300 s window — reporting `1:300:0`, which is consistent with either answer.

Recorded as cheap to resolve opportunistically the next time a 401 occurs (one valid request inside the shorter window), and explicitly **not** worth provoking deliberately, since N27 makes 401s costly regardless of the answer.

## Provenance

The originating run is recorded as rung 8 in `spikes/rust-playground/LIVE-TESTING.md`, with the journal and daemon log retained in that branch's `runs/2026-08-23-r8/`. Per that file's convention, GGG learnings are promoted to this register and to master promptly, while the spike branch records only runs.

The identical commit has been cherry-picked onto `spikes/rust-playground`, so both branches' copies of the ground-truth register are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjPPJC7eamnJfid7dkR5wK