### PR TITLE
Cmake add install phase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -832,3 +832,8 @@ add_custom_command(TARGET acquisition POST_BUILD
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
+
+install(TARGETS acquisition
+    RUNTIME DESTINATION bin
+    COMPONENT applications
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -837,3 +837,6 @@ install(TARGETS acquisition
     RUNTIME DESTINATION bin
     COMPONENT applications
 )
+
+install(FILES acquisition.desktop
+        DESTINATION share/applications/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ project(acquisition
 )
 
 include(CTest)
+include(GNUInstallDirs)
 
 # Use this to define pre-releases
 set(app_version_suffix "")
@@ -829,14 +830,31 @@ add_custom_command(TARGET acquisition POST_BUILD
     VERBATIM
 )
 
+# Install the application and the Crashpad handler it launches at runtime.
+install(TARGETS acquisition
+    BUNDLE DESTINATION . COMPONENT Runtime
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT Runtime
+)
+
+if(APPLE)
+    install(PROGRAMS "$<TARGET_FILE:crashpad_handler>"
+        DESTINATION "acquisition.app/Contents/MacOS"
+        COMPONENT Runtime
+    )
+else()
+    install(PROGRAMS "$<TARGET_FILE:crashpad_handler>"
+        DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        COMPONENT Runtime
+    )
+endif()
+
+if(UNIX AND NOT APPLE)
+    install(FILES acquisition.desktop
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications"
+        COMPONENT Runtime
+    )
+endif()
+
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
-
-install(TARGETS acquisition
-    RUNTIME DESTINATION bin
-    COMPONENT applications
-)
-
-install(FILES acquisition.desktop
-        DESTINATION share/applications/)


### PR DESCRIPTION
This PR adds proper installation rules to the CMake build system, enabling the acquisition application to be installed system-wide with desktop integration.