### PR TITLE
modlist: accumulate values when same mod appears in multiple sources

### DIFF
--- a/src/pseudomods.cpp
+++ b/src/pseudomods.cpp
@@ -10,6 +10,12 @@
 // clang-format off
 const PseudoModMap PseudoModManager::SUMMING_MODS = {
     {
+        "+# total maximum Life",
+        {
+            "+# to maximum Life"
+        }
+    },
+    {
         "+#% total to Cold Resistance",
         {
             "+#% to Cold Resistance",


### PR DESCRIPTION
Previously, when the same mod was generated from both explicit and implicit sources, the explicit value would be overwritten by the implicit one, losing the explicit contribution.

Change SumModGenerator::Generate() to add the new value to the existing entry when the mod name already exists in the output map, rather than overwriting it. This ensures both explicit and implicit mod values are combined correctly.

For example, this shield:

    Item Class: Shields
    Rarity: Rare
    Vengeance Barrier
    Pinnacle Tower Shield
    --------
    { Implicit Modifier — Life }
    +24 (20-30) to maximum Life
    --------
    { Prefix Modifier "Stout" (Tier: 7) — Life }
    +61 (55-69) to maximum Life

Before the patch, the mod table would incorrectly contain only 24 (the implicit value), discarding the explicit +61 contribution. After this fix, the values accumulate correctly to 85 total maximum Life.