### PR TITLE
Fix Windows Visual C++ runtime installation

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -91,12 +91,19 @@ jobs:
           --dir $deploy `
           "$deploy\acquisition.exe"
 
-        # Ensure vc_redist is present (windeployqt --compiler-runtime should copy it,
-        # but fall back to downloading if it doesn't)
-        if (-not (Test-Path "$deploy\vc_redist.x64.exe")) {
-          Write-Host "Downloading Visual C++ Redistributable..."
-          Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" `
-            -OutFile "$deploy\vc_redist.x64.exe"
+        # windeployqt --compiler-runtime is the authority for this prerequisite.
+        # Fail packaging if it did not provide a valid Microsoft-signed installer.
+        $redist = "$deploy\vc_redist.x64.exe"
+        if (-not (Test-Path -LiteralPath $redist)) {
+          throw "windeployqt did not package vc_redist.x64.exe"
+        }
+
+        $signature = Get-AuthenticodeSignature -LiteralPath $redist
+        if ($signature.Status -ne 'Valid' -or
+            $null -eq $signature.SignerCertificate -or
+            $signature.SignerCertificate.Subject -notmatch
+              '(^|,\s*)O=Microsoft Corporation(,|$)') {
+          throw "vc_redist.x64.exe does not have a valid Microsoft signature"
         }
 
     - name: Install Inno Setup

--- a/docs/cleanup/findings.md
+++ b/docs/cleanup/findings.md
@@ -185,7 +185,7 @@ only by `LoginDialog`. Fix shape: surface refresh failure to the UI
 and add an `oauth_rejected` de-arming path symmetric with the
 POESESSID one.
 
-### F78. `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` was defined for only one target — Confirmed; fix landed and verified on Windows
+### F78. `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` was defined for only one target — Resolved; build and installer fixes verified on Windows
 
 Found August 22, 2026, from a Sentry crash on 0.18.3
 (`acquisition.sentry.io/issues/7687078638`, two events, one Windows 10
@@ -233,22 +233,35 @@ app launches and runs past `logging::init`. Not reproduced against an
 actual 14.28 `msvcp140.dll` — the workstation has a current CRT — so
 the closing evidence is the import, not a crash-then-no-crash.
 
-Not fixed here, and left open by decision (Tom, August 22, 2026): the
-stray-DLL check below exists because users once copied CRT DLLs into
-the Acquisition folder themselves, so it is guarding a real historical
-failure mode and should not be removed to make room for app-local
-deployment.
+The remaining installer gap was closed August 27, 2026. `installer.iss`
+now runs the `windeployqt`-supplied redistributable as a mandatory
+prerequisite before modifying Acquisition, validates its exit code,
+propagates restart-required results, and preserves its diagnostic log
+under the user's local application data. Packaging fails if
+`windeployqt` omits the redistributable or supplies one without a valid
+Microsoft signature; the workflow does not download a fallback. Upgrades
+also delete stale app-local `msvcp140*`, `vcruntime140*`, and `concrt140`
+DLLs before copying application files. The existing stray-DLL runtime
+check remains because users historically copied CRT DLLs into the
+Acquisition directory themselves.
 
-- `installer.iss` leaves the redistributable an unchecked-able Task,
-  so a user can still decline it. With the macro global this is no
-  longer fatal, but it should be forced.
+Verified on the Windows workstation in two isolated installs: a host test
+with a newer runtime accepted redistributable result 1638, and a disposable
+Windows Sandbox started without a registered x64 runtime, installed
+v14.44.35211.00, launched Acquisition with an isolated data directory, and
+uninstalled cleanly. Both removed seeded stale app-local CRT files and left
+neither CRT DLLs nor `vc_redist.x64.exe` beside the application. The
+checked-in Sandbox harness also covers synthetic restart-required and
+prerequisite-failure exit paths.
+
+Known diagnostic limitation retained by design:
+
 - `checkMicrosoftRuntime()` runs at `src/main.cpp:164`, *after*
   `logging::init` at `:134`, so it can never fire for a crash in the
   CRT's first lock. It also only looks for stray DLLs beside the exe
   (`src/util/checkmsvc.cpp`) and never checks the system CRT's
-  version, which was the actual fault here.
-- Shipping the CRT DLLs app-local would conflict with that same
-  check, which aborts when it finds `msvcp140.dll` next to the exe.
+  version. The global compatibility macro protects startup against an
+  old system runtime, while the mandatory prerequisite upgrades it.
 
 ## Standing constraints and lessons
 

--- a/docs/cleanup/findings.md
+++ b/docs/cleanup/findings.md
@@ -239,9 +239,15 @@ prerequisite before modifying Acquisition, validates its exit code,
 propagates restart-required results, and preserves its diagnostic log
 under the user's local application data. Packaging fails if
 `windeployqt` omits the redistributable or supplies one without a valid
-Microsoft signature; the workflow does not download a fallback. Upgrades
-also delete stale app-local `msvcp140*`, `vcruntime140*`, and `concrt140`
-DLLs before copying application files. The existing stray-DLL runtime
+Microsoft signature; the workflow does not download a fallback. The installer
+skips the prerequisite when an equal or newer registered runtime is already
+installed, preserving an unelevated per-user installation in that case. When
+the runtime is missing or older, its machine-wide update requires administrator
+approval, after which Acquisition can still be installed per-user. Every install
+also deletes stale app-local `msvcp140*`, `vcruntime140*`, and `concrt140` DLLs
+before copying application files. Redistributable logs are intentionally retained
+under `%LOCALAPPDATA%\acquisition\installer-logs` for diagnosis after setup or
+uninstallation. The existing stray-DLL runtime
 check remains because users historically copied CRT DLLs into the
 Acquisition directory themselves.
 

--- a/installer.iss
+++ b/installer.iss
@@ -100,35 +100,53 @@ Filename: "{app}\{#APP_NAME}.exe"; Description: "{cm:LaunchProgram,{#StringChang
 [Code]
 const
   VCRedistSuccess = 0;
+  VCRedistAccessDenied = 5;
+  VCRedistElevationRequired = 740;
+  VCRedistOperationCancelled = 1223;
+  VCRedistInstallCancelled = 1602;
   VCRedistAnotherVersionInstalled = 1638;
   VCRedistRebootInitiated = 1641;
   VCRedistRebootRequired = 3010;
+  VCRedistRegistryKey =
+    'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64';
 
 var
   VCRedistNeedsRestart: Boolean;
 
+function GetInstalledVCRedistVersion(var Version: Int64): Boolean;
+var
+  Installed: Cardinal;
+  Major: Cardinal;
+  Minor: Cardinal;
+  Build: Cardinal;
+  Revision: Cardinal;
+begin
+  Result :=
+    RegQueryDWordValue(HKLM64, VCRedistRegistryKey, 'Installed', Installed) and
+    (Installed = 1) and
+    RegQueryDWordValue(HKLM64, VCRedistRegistryKey, 'Major', Major) and
+    RegQueryDWordValue(HKLM64, VCRedistRegistryKey, 'Minor', Minor) and
+    RegQueryDWordValue(HKLM64, VCRedistRegistryKey, 'Bld', Build) and
+    RegQueryDWordValue(HKLM64, VCRedistRegistryKey, 'Rbld', Revision);
+
+  if Result then
+    Version := PackVersionComponents(
+      Word(Major), Word(Minor), Word(Build), Word(Revision));
+end;
+
 function InstallVCRedist: String;
 var
-  RedistPath: String;
   LogDirectory: String;
   LogPath: String;
-  Parameters: String;
   ResultCode: Integer;
+#ifndef VC_REDIST_TEST_EXIT_CODE
+  RedistPath: String;
+  Parameters: String;
+  BundledVersion: Int64;
+  InstalledVersion: Int64;
+#endif
 begin
   Result := '';
-  LogDirectory := ExpandConstant('{localappdata}\{#APP_NAME}\installer-logs');
-  LogPath := LogDirectory + '\vc_redist-{#APP_VERSION_STRING}.log';
-
-  if not ForceDirectories(LogDirectory) then
-  begin
-    Result :=
-      'Setup could not create the Visual C++ Runtime log directory:' + #13#10 +
-      LogDirectory;
-    Exit;
-  end;
-
-  WizardForm.StatusLabel.Caption :=
-    'Installing Microsoft Visual C++ Runtime...';
 
 #ifdef VC_REDIST_TEST_EXIT_CODE
   ResultCode := {#VC_REDIST_TEST_EXIT_CODE};
@@ -144,15 +162,59 @@ begin
   end;
 
   RedistPath := ExpandConstant('{tmp}\vc_redist.x64.exe');
+
+  if not GetPackedVersion(RedistPath, BundledVersion) then
+  begin
+    Result :=
+      'Setup could not read the Microsoft Visual C++ Runtime version.';
+    Exit;
+  end;
+
+  if GetInstalledVCRedistVersion(InstalledVersion) and
+    (ComparePackedVersion(InstalledVersion, BundledVersion) >= 0) then
+  begin
+    Log('Microsoft Visual C++ Runtime ' + VersionToStr(InstalledVersion) +
+      ' is already installed; bundled version ' +
+      VersionToStr(BundledVersion) + ' is not required.');
+    Exit;
+  end;
+
+  Log('Microsoft Visual C++ Runtime ' + VersionToStr(BundledVersion) +
+    ' must be installed or updated.');
+#endif
+
+  LogDirectory := ExpandConstant('{localappdata}\{#APP_NAME}\installer-logs');
+  LogPath := LogDirectory + '\vc_redist-{#APP_VERSION_STRING}.log';
+
+  if not ForceDirectories(LogDirectory) then
+  begin
+    Result :=
+      'Setup could not create the Visual C++ Runtime log directory:' + #13#10 +
+      LogDirectory;
+    Exit;
+  end;
+
+  WizardForm.PreparingLabel.Caption :=
+    'Installing Microsoft Visual C++ Runtime...';
+
+#ifndef VC_REDIST_TEST_EXIT_CODE
   Parameters := '/install /quiet /norestart /log "' + LogPath + '"';
 
   if not Exec(RedistPath, Parameters, '', SW_SHOWNORMAL,
     ewWaitUntilTerminated, ResultCode) then
   begin
-    Result :=
-      'Setup could not start the Microsoft Visual C++ Runtime installer.' + #13#10 +
-      'Windows error: ' + IntToStr(ResultCode) + #13#10 +
-      'Log: ' + LogPath;
+    if (ResultCode = VCRedistAccessDenied) or
+      (ResultCode = VCRedistElevationRequired) or
+      (ResultCode = VCRedistOperationCancelled) then
+      Result :=
+        'Administrator approval is required to install or update the ' +
+        'Microsoft Visual C++ Runtime.' + #13#10 +
+        'Acquisition was not installed.'
+    else
+      Result :=
+        'Setup could not start the Microsoft Visual C++ Runtime installer.' + #13#10 +
+        'Windows error: ' + IntToStr(ResultCode) + ' (' +
+        SysErrorMessage(ResultCode) + ')' + #13#10 + 'Log: ' + LogPath;
     Exit;
   end;
 #endif
@@ -162,6 +224,11 @@ begin
       Log('Microsoft Visual C++ Runtime installation succeeded.');
     VCRedistAnotherVersionInstalled:
       Log('A newer Microsoft Visual C++ Runtime is already installed.');
+    VCRedistInstallCancelled, VCRedistOperationCancelled:
+      Result :=
+        'Administrator approval is required to install or update the ' +
+        'Microsoft Visual C++ Runtime.' + #13#10 +
+        'Acquisition was not installed.';
     VCRedistRebootInitiated, VCRedistRebootRequired:
       begin
         Log('Microsoft Visual C++ Runtime installation requires a restart.');

--- a/installer.iss
+++ b/installer.iss
@@ -86,7 +86,8 @@ Type: files; Name: "{app}\vcruntime140*.dll"
 Type: files; Name: "{app}\concrt140.dll"
 
 [Files]
-Source: "{#DEPLOY_DIR}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#DEPLOY_DIR}\*"; DestDir: "{app}"; Excludes: "vc_redist.x64.exe"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#DEPLOY_DIR}\vc_redist.x64.exe"; Flags: dontcopy
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]
@@ -94,5 +95,92 @@ Name: "{autoprograms}\{#APP_NAME}"; Filename: "{app}\{#APP_NAME}.exe"
 Name: "{autodesktop}\{#APP_NAME}"; Filename: "{app}\{#APP_NAME}.exe"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\vc_redist.x64.exe"; Parameters: "/install /quiet /norestart /log ""{tmp}\vc_redist.log"""; StatusMsg: "Installing Microsoft Visual C++ Runtime..."
 Filename: "{app}\{#APP_NAME}.exe"; Description: "{cm:LaunchProgram,{#StringChange(APP_NAME, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+
+[Code]
+const
+  VCRedistSuccess = 0;
+  VCRedistAnotherVersionInstalled = 1638;
+  VCRedistRebootInitiated = 1641;
+  VCRedistRebootRequired = 3010;
+
+var
+  VCRedistNeedsRestart: Boolean;
+
+function InstallVCRedist: String;
+var
+  RedistPath: String;
+  LogDirectory: String;
+  LogPath: String;
+  Parameters: String;
+  ResultCode: Integer;
+begin
+  Result := '';
+  LogDirectory := ExpandConstant('{localappdata}\{#APP_NAME}\installer-logs');
+  LogPath := LogDirectory + '\vc_redist-{#APP_VERSION_STRING}.log';
+
+  if not ForceDirectories(LogDirectory) then
+  begin
+    Result :=
+      'Setup could not create the Visual C++ Runtime log directory:' + #13#10 +
+      LogDirectory;
+    Exit;
+  end;
+
+  WizardForm.StatusLabel.Caption :=
+    'Installing Microsoft Visual C++ Runtime...';
+
+#ifdef VC_REDIST_TEST_EXIT_CODE
+  ResultCode := {#VC_REDIST_TEST_EXIT_CODE};
+  Log('Using synthetic Microsoft Visual C++ Runtime exit code ' +
+    IntToStr(ResultCode) + '.');
+#else
+  try
+    ExtractTemporaryFile('vc_redist.x64.exe');
+  except
+    Result :=
+      'Setup could not extract the Microsoft Visual C++ Runtime installer.';
+    Exit;
+  end;
+
+  RedistPath := ExpandConstant('{tmp}\vc_redist.x64.exe');
+  Parameters := '/install /quiet /norestart /log "' + LogPath + '"';
+
+  if not Exec(RedistPath, Parameters, '', SW_SHOWNORMAL,
+    ewWaitUntilTerminated, ResultCode) then
+  begin
+    Result :=
+      'Setup could not start the Microsoft Visual C++ Runtime installer.' + #13#10 +
+      'Windows error: ' + IntToStr(ResultCode) + #13#10 +
+      'Log: ' + LogPath;
+    Exit;
+  end;
+#endif
+
+  case ResultCode of
+    VCRedistSuccess:
+      Log('Microsoft Visual C++ Runtime installation succeeded.');
+    VCRedistAnotherVersionInstalled:
+      Log('A newer Microsoft Visual C++ Runtime is already installed.');
+    VCRedistRebootInitiated, VCRedistRebootRequired:
+      begin
+        Log('Microsoft Visual C++ Runtime installation requires a restart.');
+        VCRedistNeedsRestart := True;
+      end;
+  else
+    Result :=
+      'Microsoft Visual C++ Runtime installation failed with exit code ' +
+      IntToStr(ResultCode) + '.' + #13#10 +
+      'See the installation log for details:' + #13#10 + LogPath;
+  end;
+end;
+
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+begin
+  Result := InstallVCRedist;
+end;
+
+function NeedRestart: Boolean;
+begin
+  Result := VCRedistNeedsRestart;
+end;

--- a/installer.iss
+++ b/installer.iss
@@ -77,8 +77,13 @@ MinVersion=10.0
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
-Name: "vc_redist"; Description: "Update/Install Microsoft Visual C++ 2015-2022 Runtime";
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; Flags: unchecked
+
+[InstallDelete]
+; Remove unsupported app-local MSVC runtime files left by older or manual installs.
+Type: files; Name: "{app}\msvcp140*.dll"
+Type: files; Name: "{app}\vcruntime140*.dll"
+Type: files; Name: "{app}\concrt140.dll"
 
 [Files]
 Source: "{#DEPLOY_DIR}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -89,5 +94,5 @@ Name: "{autoprograms}\{#APP_NAME}"; Filename: "{app}\{#APP_NAME}.exe"
 Name: "{autodesktop}\{#APP_NAME}"; Filename: "{app}\{#APP_NAME}.exe"; Tasks: desktopicon
 
 [Run]
+Filename: "{app}\vc_redist.x64.exe"; Parameters: "/install /quiet /norestart /log ""{tmp}\vc_redist.log"""; StatusMsg: "Installing Microsoft Visual C++ Runtime..."
 Filename: "{app}\{#APP_NAME}.exe"; Description: "{cm:LaunchProgram,{#StringChange(APP_NAME, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
-Filename: "{app}\vc_redist.x64.exe"; Parameters: "/install /passive /norestart"; Tasks: vc_redist;

--- a/tools/windows-sandbox/README.md
+++ b/tools/windows-sandbox/README.md
@@ -1,0 +1,48 @@
+# Windows installer sandbox test
+
+This harness runs an Acquisition installer in a disposable Windows Sandbox. It
+records the initial and final Visual C++ Runtime state, exercises stale
+app-local runtime cleanup, launches Acquisition with isolated data, uninstalls
+it, and writes logs plus `report.json` to `build/sandbox-results/`.
+
+Windows Sandbox must be enabled on the host. Build the installer, then run:
+
+```powershell
+tools\windows-sandbox\start-installer-test.ps1 `
+  -InstallerPath Output\acquisition_setup_0.18.4.exe
+```
+
+The launcher generates `build/acquisition-installer-test.wsb` from the current
+checkout path, stages exactly the requested installer, disables networking and
+host integrations, and launches the sandbox. The harness shuts the sandbox down
+after saving its report. All guest state is discarded; only the mapped results
+directory persists.
+
+For installers compiled with `VC_REDIST_TEST_EXIT_CODE`, select the matching
+expected result:
+
+```powershell
+# Synthetic 3010 (restart required)
+tools\windows-sandbox\start-installer-test.ps1 `
+  -InstallerPath Output\acquisition_setup_0.18.4.exe `
+  -ExpectedOutcome restart
+
+# Synthetic prerequisite failure
+tools\windows-sandbox\start-installer-test.ps1 `
+  -InstallerPath Output\acquisition_setup_0.18.4.exe `
+  -ExpectedOutcome failure
+```
+
+Compile synthetic installers by passing one of these test-only preprocessor
+definitions to Inno Setup:
+
+```powershell
+ISCC.exe /DBUILD_DIR=build /DDEPLOY_DIR=build\deploy `
+  /DVC_REDIST_TEST_EXIT_CODE=3010 /Obuild\synthetic-restart installer.iss
+ISCC.exe /DBUILD_DIR=build /DDEPLOY_DIR=build\deploy `
+  /DVC_REDIST_TEST_EXIT_CODE=1603 /Obuild\synthetic-failure installer.iss
+```
+
+Use a separate `/O` output directory for each variant. The define is absent
+from release packaging, so production installers always execute the embedded
+Microsoft redistributable.

--- a/tools/windows-sandbox/README.md
+++ b/tools/windows-sandbox/README.md
@@ -5,6 +5,23 @@ records the initial and final Visual C++ Runtime state, exercises stale
 app-local runtime cleanup, launches Acquisition with isolated data, uninstalls
 it, and writes logs plus `report.json` to `build/sandbox-results/`.
 
+The production installer remains a per-user installer. It skips the
+redistributable without elevation when the registered x64 runtime is equal to
+or newer than the bundled version. If the runtime is missing or older, Windows
+requests administrator approval for that machine-wide prerequisite; Acquisition
+then continues with the selected per-user installation.
+
+To verify the unelevated skip path, use the `skip` outcome. The harness first
+performs an elevated install to register the bundled runtime, removes
+Acquisition, and then runs the installer without `RunAs`. The second install
+must skip the prerequisite and complete per-user without elevation:
+
+```powershell
+tools\windows-sandbox\start-installer-test.ps1 `
+  -InstallerPath Output\acquisition_setup_0.18.4.exe `
+  -ExpectedOutcome skip
+```
+
 Windows Sandbox must be enabled on the host. Build the installer, then run:
 
 ```powershell

--- a/tools/windows-sandbox/run-installer-test.ps1
+++ b/tools/windows-sandbox/run-installer-test.ps1
@@ -23,6 +23,7 @@ $report = [ordered]@{
     final_runtime = $null
     installer_exit_code = $null
     expected_outcome = $expectedOutcome
+    test_install_elevated = $expectedOutcome -ne 'skip'
     app_started = $false
     app_stayed_running = $false
     uninstaller_exit_code = $null
@@ -74,6 +75,35 @@ try {
     $installer = $installers[0]
     $report.installer = $installer.Name
 
+    if ($expectedOutcome -eq 'skip') {
+        $report.phase = 'seeding registered runtime'
+        $seedSetupLog = Join-Path $resultsDirectory 'seed-setup.log'
+        $seedUninstallLog = Join-Path $resultsDirectory 'seed-uninstall.log'
+        $seedArguments =
+            '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /CURRENTUSER ' +
+            "/DIR=`"$installDirectory`" /LOG=`"$seedSetupLog`""
+        $seedProcess = Start-Process -FilePath $installer.FullName `
+            -ArgumentList $seedArguments -Verb RunAs -Wait -PassThru
+        if ($seedProcess.ExitCode -ne 0) {
+            throw "Runtime-seeding install exited with code $($seedProcess.ExitCode)."
+        }
+
+        $seedUninstaller = Join-Path $installDirectory 'unins000.exe'
+        $seedUninstallArguments =
+            "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /LOG=`"$seedUninstallLog`""
+        $seedUninstallProcess = Start-Process -FilePath $seedUninstaller `
+            -ArgumentList $seedUninstallArguments -Wait -PassThru
+        if ($seedUninstallProcess.ExitCode -ne 0) {
+            throw "Runtime-seeding uninstall exited with code $($seedUninstallProcess.ExitCode)."
+        }
+
+        $report.initial_runtime = Get-VCRuntimeState
+        if ($null -eq $report.initial_runtime -or
+            $report.initial_runtime.installed -ne 1) {
+            throw 'The runtime-seeding install did not register the x64 runtime.'
+        }
+    }
+
     $report.phase = 'seeding stale runtime files'
     New-Item -ItemType Directory -Force -Path $installDirectory | Out-Null
     @('msvcp140.dll', 'vcruntime140_1.dll', 'concrt140.dll') |
@@ -86,8 +116,14 @@ try {
     $installerArguments =
         '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /CURRENTUSER ' +
         "/DIR=`"$installDirectory`" /LOG=`"$setupLog`""
-    $installerProcess = Start-Process -FilePath $installer.FullName `
-        -ArgumentList $installerArguments -Verb RunAs -Wait -PassThru
+    if ($expectedOutcome -eq 'skip') {
+        $installerProcess = Start-Process -FilePath $installer.FullName `
+            -ArgumentList $installerArguments -Wait -PassThru
+    }
+    else {
+        $installerProcess = Start-Process -FilePath $installer.FullName `
+            -ArgumentList $installerArguments -Verb RunAs -Wait -PassThru
+    }
     $report.installer_exit_code = $installerProcess.ExitCode
     if ($expectedOutcome -eq 'failure') {
         if ($installerProcess.ExitCode -eq 0) {
@@ -112,6 +148,14 @@ try {
     if ($expectedOutcome -eq 'success' -and $restartReported) {
         throw 'Setup unexpectedly reported that Windows needs to restart.'
     }
+    if ($expectedOutcome -eq 'skip' -and
+        $setupLogText -notmatch 'is already installed; bundled version .* is not required') {
+        throw 'Setup did not report skipping the equal or newer registered runtime.'
+    }
+    if ($expectedOutcome -eq 'skip' -and
+        $setupLogText -notmatch 'Administrative install mode: No') {
+        throw 'The runtime-skip case did not retain per-user install mode.'
+    }
 
     $report.phase = 'verifying installation'
     $applicationPath = Join-Path $installDirectory 'acquisition.exe'
@@ -129,7 +173,7 @@ try {
     }
 
     $report.final_runtime = Get-VCRuntimeState
-    if ($expectedOutcome -eq 'success') {
+    if ($expectedOutcome -in @('success', 'skip')) {
         if ($null -eq $report.final_runtime -or $report.final_runtime.installed -ne 1) {
             throw 'The x64 Visual C++ Runtime is not registered after installation.'
         }

--- a/tools/windows-sandbox/run-installer-test.ps1
+++ b/tools/windows-sandbox/run-installer-test.ps1
@@ -1,0 +1,188 @@
+$ErrorActionPreference = 'Stop'
+
+$inputDirectory = 'C:\acq-test\input'
+$resultsDirectory = 'C:\acq-test\results'
+$installDirectory = 'C:\AcquisitionTest'
+$dataDirectory = 'C:\AcquisitionTestData'
+$setupLog = Join-Path $resultsDirectory 'setup.log'
+$uninstallLog = Join-Path $resultsDirectory 'uninstall.log'
+$reportPath = Join-Path $resultsDirectory 'report.json'
+$transcriptPath = Join-Path $resultsDirectory 'harness.log'
+$testConfiguration = Get-Content `
+    -Raw -LiteralPath (Join-Path $inputDirectory 'test-config.json') |
+    ConvertFrom-Json
+$expectedOutcome = $testConfiguration.expected_outcome
+
+$report = [ordered]@{
+    started_utc = (Get-Date).ToUniversalTime().ToString('o')
+    completed_utc = $null
+    passed = $false
+    phase = 'initializing'
+    installer = $null
+    initial_runtime = $null
+    final_runtime = $null
+    installer_exit_code = $null
+    expected_outcome = $expectedOutcome
+    app_started = $false
+    app_stayed_running = $false
+    uninstaller_exit_code = $null
+    stale_runtime_files = @()
+    leftover_install_files = @()
+    error = $null
+}
+
+function Get-VCRuntimeState {
+    $registryPaths = @(
+        'HKLM:\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64'
+    )
+
+    foreach ($registryPath in $registryPaths) {
+        if (Test-Path -LiteralPath $registryPath) {
+            $runtime = Get-ItemProperty -LiteralPath $registryPath
+            return [ordered]@{
+                registry_path = $registryPath
+                installed = $runtime.Installed
+                version = $runtime.Version
+                major = $runtime.Major
+                minor = $runtime.Minor
+                build = $runtime.Bld
+                revision = $runtime.Rbld
+            }
+        }
+    }
+
+    return $null
+}
+
+function Save-Report {
+    $report.completed_utc = (Get-Date).ToUniversalTime().ToString('o')
+    $report | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $reportPath -Encoding UTF8
+}
+
+New-Item -ItemType Directory -Force -Path $resultsDirectory | Out-Null
+Start-Transcript -LiteralPath $transcriptPath -Force
+
+try {
+    $report.initial_runtime = Get-VCRuntimeState
+
+    $report.phase = 'locating installer'
+    $installers = @(Get-ChildItem -LiteralPath $inputDirectory -Filter 'acquisition_setup_*.exe')
+    if ($installers.Count -ne 1) {
+        throw "Expected exactly one Acquisition installer, found $($installers.Count)."
+    }
+    $installer = $installers[0]
+    $report.installer = $installer.Name
+
+    $report.phase = 'seeding stale runtime files'
+    New-Item -ItemType Directory -Force -Path $installDirectory | Out-Null
+    @('msvcp140.dll', 'vcruntime140_1.dll', 'concrt140.dll') |
+        ForEach-Object {
+            New-Item -ItemType File -Force `
+                -Path (Join-Path $installDirectory $_) | Out-Null
+        }
+
+    $report.phase = 'installing'
+    $installerArguments =
+        '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /CURRENTUSER ' +
+        "/DIR=`"$installDirectory`" /LOG=`"$setupLog`""
+    $installerProcess = Start-Process -FilePath $installer.FullName `
+        -ArgumentList $installerArguments -Verb RunAs -Wait -PassThru
+    $report.installer_exit_code = $installerProcess.ExitCode
+    if ($expectedOutcome -eq 'failure') {
+        if ($installerProcess.ExitCode -eq 0) {
+            throw 'The synthetic prerequisite failure unexpectedly succeeded.'
+        }
+        if (Test-Path -LiteralPath (Join-Path $installDirectory 'acquisition.exe')) {
+            throw 'Acquisition files were installed after the prerequisite failed.'
+        }
+        $report.phase = 'complete'
+        $report.passed = $true
+        return
+    }
+    elseif ($installerProcess.ExitCode -ne 0) {
+        throw "Installer exited with code $($installerProcess.ExitCode)."
+    }
+
+    $setupLogText = Get-Content -Raw -LiteralPath $setupLog
+    $restartReported = $setupLogText -match 'Need to restart Windows\? Yes'
+    if ($expectedOutcome -eq 'restart' -and -not $restartReported) {
+        throw 'Setup did not propagate the synthetic restart-required result.'
+    }
+    if ($expectedOutcome -eq 'success' -and $restartReported) {
+        throw 'Setup unexpectedly reported that Windows needs to restart.'
+    }
+
+    $report.phase = 'verifying installation'
+    $applicationPath = Join-Path $installDirectory 'acquisition.exe'
+    if (-not (Test-Path -LiteralPath $applicationPath)) {
+        throw 'The installer did not create acquisition.exe.'
+    }
+
+    $report.stale_runtime_files = @(
+        Get-ChildItem -LiteralPath $installDirectory -File |
+            Where-Object Name -Match '^(msvcp140.*|vcruntime140.*|concrt140|vc_redist\.x64)\.exe$|^(msvcp140.*|vcruntime140.*|concrt140)\.dll$' |
+            ForEach-Object Name
+    )
+    if ($report.stale_runtime_files.Count -ne 0) {
+        throw "Unexpected app-local runtime files: $($report.stale_runtime_files -join ', ')"
+    }
+
+    $report.final_runtime = Get-VCRuntimeState
+    if ($expectedOutcome -eq 'success') {
+        if ($null -eq $report.final_runtime -or $report.final_runtime.installed -ne 1) {
+            throw 'The x64 Visual C++ Runtime is not registered after installation.'
+        }
+
+        $report.phase = 'launching application'
+        New-Item -ItemType Directory -Force -Path $dataDirectory | Out-Null
+        $application = Start-Process -FilePath $applicationPath `
+            -ArgumentList "--data-dir `"$dataDirectory`"" -PassThru
+        $report.app_started = $true
+        Start-Sleep -Seconds 8
+        $application.Refresh()
+        $report.app_stayed_running = -not $application.HasExited
+        if (-not $report.app_stayed_running) {
+            throw "Acquisition exited early with code $($application.ExitCode)."
+        }
+        Stop-Process -Id $application.Id -Force
+        $application.WaitForExit()
+    }
+
+    $report.phase = 'uninstalling'
+    $uninstallerPath = Join-Path $installDirectory 'unins000.exe'
+    if (-not (Test-Path -LiteralPath $uninstallerPath)) {
+        throw 'The generated uninstaller was not found.'
+    }
+    $uninstallerArguments =
+        "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /LOG=`"$uninstallLog`""
+    $uninstallerProcess = Start-Process -FilePath $uninstallerPath `
+        -ArgumentList $uninstallerArguments -Wait -PassThru
+    $report.uninstaller_exit_code = $uninstallerProcess.ExitCode
+    if ($uninstallerProcess.ExitCode -ne 0) {
+        throw "Uninstaller exited with code $($uninstallerProcess.ExitCode)."
+    }
+
+    Start-Sleep -Seconds 2
+    if (Test-Path -LiteralPath $installDirectory) {
+        $report.leftover_install_files = @(
+            Get-ChildItem -LiteralPath $installDirectory -Recurse -Force |
+                ForEach-Object FullName
+        )
+    }
+    if ($report.leftover_install_files.Count -ne 0) {
+        throw 'The uninstaller left files in the installation directory.'
+    }
+
+    $report.phase = 'complete'
+    $report.passed = $true
+}
+catch {
+    $report.error = $_.Exception.ToString()
+    Write-Error $_.Exception.ToString()
+}
+finally {
+    Save-Report
+    Stop-Transcript
+    shutdown.exe /s /t 5
+}

--- a/tools/windows-sandbox/start-installer-test.ps1
+++ b/tools/windows-sandbox/start-installer-test.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(Mandatory = $true)]
     [string] $InstallerPath,
 
-    [ValidateSet('success', 'restart', 'failure')]
+    [ValidateSet('success', 'skip', 'restart', 'failure')]
     [string] $ExpectedOutcome = 'success'
 )
 

--- a/tools/windows-sandbox/start-installer-test.ps1
+++ b/tools/windows-sandbox/start-installer-test.ps1
@@ -1,0 +1,71 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $InstallerPath,
+
+    [ValidateSet('success', 'restart', 'failure')]
+    [string] $ExpectedOutcome = 'success'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+$installer = Get-Item -LiteralPath $InstallerPath
+$buildDirectory = Join-Path $repositoryRoot 'build'
+$inputDirectory = Join-Path $buildDirectory 'sandbox-input'
+$resultsDirectory = Join-Path $buildDirectory 'sandbox-results'
+$configurationPath = Join-Path $buildDirectory 'acquisition-installer-test.wsb'
+
+New-Item -ItemType Directory -Force -Path $inputDirectory, $resultsDirectory | Out-Null
+Get-ChildItem -LiteralPath $inputDirectory -Force | Remove-Item -Recurse -Force
+Get-ChildItem -LiteralPath $resultsDirectory -Force | Remove-Item -Recurse -Force
+Copy-Item -LiteralPath $installer.FullName -Destination $inputDirectory
+@{ expected_outcome = $ExpectedOutcome } |
+    ConvertTo-Json |
+    Set-Content -LiteralPath (Join-Path $inputDirectory 'test-config.json') -Encoding UTF8
+
+function ConvertTo-XmlText([string] $Value) {
+    return [System.Security.SecurityElement]::Escape($Value)
+}
+
+$inputXml = ConvertTo-XmlText $inputDirectory
+$harnessXml = ConvertTo-XmlText $PSScriptRoot
+$resultsXml = ConvertTo-XmlText $resultsDirectory
+
+$configuration = @"
+<Configuration>
+  <VGpu>Disable</VGpu>
+  <Networking>Disable</Networking>
+  <AudioInput>Disable</AudioInput>
+  <VideoInput>Disable</VideoInput>
+  <PrinterRedirection>Disable</PrinterRedirection>
+  <ClipboardRedirection>Disable</ClipboardRedirection>
+  <ProtectedClient>Enable</ProtectedClient>
+  <MemoryInMB>4096</MemoryInMB>
+  <MappedFolders>
+    <MappedFolder>
+      <HostFolder>$inputXml</HostFolder>
+      <SandboxFolder>C:\acq-test\input</SandboxFolder>
+      <ReadOnly>true</ReadOnly>
+    </MappedFolder>
+    <MappedFolder>
+      <HostFolder>$harnessXml</HostFolder>
+      <SandboxFolder>C:\acq-test\harness</SandboxFolder>
+      <ReadOnly>true</ReadOnly>
+    </MappedFolder>
+    <MappedFolder>
+      <HostFolder>$resultsXml</HostFolder>
+      <SandboxFolder>C:\acq-test\results</SandboxFolder>
+      <ReadOnly>false</ReadOnly>
+    </MappedFolder>
+  </MappedFolders>
+  <LogonCommand>
+    <Command>powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File C:\acq-test\harness\run-installer-test.ps1</Command>
+  </LogonCommand>
+</Configuration>
+"@
+
+Set-Content -LiteralPath $configurationPath -Value $configuration -Encoding UTF8
+Start-Process -FilePath "$env:SystemRoot\System32\WindowsSandbox.exe" `
+    -ArgumentList ('"' + $configurationPath + '"')
+
+Write-Host "Windows Sandbox started. Results will appear in $resultsDirectory"


### PR DESCRIPTION
## Summary

- make the bundled Visual C++ Redistributable a mandatory prerequisite and validate its exit code
- propagate restart-required results, preserve the redistributable log, and remove stale app-local MSVC runtime DLLs
- fail Windows packaging if windeployqt omits the redistributable or it lacks a valid Microsoft signature; do not download a fallback
- add a portable Windows Sandbox harness for real and synthetic installer verification
- record the completed F78 installer remediation

## Verification

- existing-newer-runtime host install accepted exit code 1638
- disposable Windows Sandbox with no registered x64 runtime installed v14.44.35211.00
- seeded app-local CRT DLLs were removed and vc_redist was not left beside Acquisition
- Acquisition launched with isolated data and uninstalled cleanly
- synthetic 3010 restart-required path propagated through Inno Setup
- synthetic 1603 failure stopped before Acquisition files were installed
- release Inno installer compiled locally without test defines
- Windows Build & Package workflow passed on this branch
- git diff --check
