### PR TITLE
qdarkstyle: switch to shared library to fix linker error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -858,3 +858,5 @@ endif()
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
+
+target_link_libraries(qdarkstyle PRIVATE Qt6::Core)


### PR DESCRIPTION
Fixes:
/usr/bin/ld: copy relocation against non-copyable protected symbol `qt_resourceFeatureZstd@@Qt_6' in libQt6Core.so.6.11.2

Static build of qdarkstyle caused symbol relocation issues with Qt6Core. Building as SHARED resolves the problem.