### PR TITLE
Prepare 0.18.5: user guide, Help menu, GCC 16 warning fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.24)
 # tags on github are prefixed with a 'v'.
 
 project(acquisition
-    VERSION 0.18.4
+    VERSION 0.18.5
     DESCRIPTION "Stash and forum shop management for Path of Exile (TM)"
     HOMEPAGE_URL "https://github.com/gerwaric/acquisition"
     LANGUAGES CXX

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Acquisition can run on Windows, macOS, Linux.
 
 You can download setup packages from [the releases page](https://github.com/gerwaric/acquisition/releases).
 
+## User guide
+
+The [user guide](docs/user/README.md) covers logging in, searching and filters, mods and pseudomods, pricing, forum shops, currency tracking, and troubleshooting. It is also reachable from the **Help** menu inside the application.
+
 ## Building Acquisition
 
 Acquisition is written in C++ and uses the Qt widget toolkit. It was originally a qmake project, but has been migrated to cmake.

--- a/deps/qdarkstyle/CMakeLists.txt
+++ b/deps/qdarkstyle/CMakeLists.txt
@@ -6,3 +6,21 @@ add_library(qdarkstyle STATIC
 set_target_properties(qdarkstyle PROPERTIES
     AUTORCC ON
 )
+
+# Qt6::Core is linked for its usage requirements, not its headers: the
+# rcc-generated sources include no Qt header at all, so this target would
+# otherwise be compiled with none of Qt's required consumer flags.
+#
+# Where Qt is built with -DFEATURE_reduce_relocations=ON (Arch and other
+# distros), it exports qt_resourceFeatureZstd with protected visibility, and
+# the generated resource code references that symbol directly. A direct
+# reference forces the linker to emit a copy relocation, which is illegal
+# against a protected symbol:
+#
+#   /usr/bin/ld: libqdarkstyle.a(qrc_lightstyle.cpp.o): copy relocation
+#   against non-copyable protected symbol `qt_resourceFeatureZstd@@Qt_6'
+#
+# Linking Qt6::Core applies the flag that Qt build requires of its consumers
+# (-mno-direct-extern-access, or -fPIC on kits without it), routing the
+# reference through the GOT so no copy relocation is needed.
+target_link_libraries(qdarkstyle PRIVATE Qt6::Core)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,13 @@ One line per document, plus the traceability rules that connect them.
 Each document also states its own status and provenance in its header;
 when this map and a header disagree, the header wins.
 
+## User-facing
+
+- `user/README.md` — index of the end-user guide (`user/*.md`): login,
+  searching, mods and pseudomods, pricing, forum shop, currency, settings.
+  Written from source in August 2026; linked from the top-level README and
+  the application's Help menu.
+
 ## Active
 
 - `design/legacy-buyout-import.md` — deliberately minimal design for

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,0 +1,45 @@
+# Acquisition User Guide
+
+Acquisition downloads your Path of Exile stash tabs and character inventories so
+you can search them offline, price items, and publish those prices to forum shop
+threads that the official trade site indexes.
+
+Acquisition is neither affiliated with nor endorsed by Grinding Gear Games.
+
+## Pages
+
+| Page | What it covers |
+|---|---|
+| [Getting started](getting-started.md) | Installing, logging in with OAuth, choosing a realm and league, where your data lives |
+| [Searching](searching.md) | Search tabs, the By Tab / By Item views, every filter, and the item table columns |
+| [Mods and pseudomods](mods-and-pseudomods.md) | The Mods filter and the 35 summed "total" pseudomods |
+| [Pricing](pricing.md) | Buyout types, tab-level prices and inheritance, in-game prices, legacy buyout import |
+| [Forum shop](forum-shop.md) | Shop threads, the shop template, POESESSID, automatic shop updates |
+| [Currency](currency.md) | The currency overview dialog and CSV export |
+| [Settings and troubleshooting](settings-and-troubleshooting.md) | Refresh modes, rate limiting, themes, logging, updates, crash reports, data files |
+
+## Sixty-second overview
+
+1. Launch Acquisition and click **Authenticate**. A browser window opens for the
+   Path of Exile OAuth grant. Pick a realm and league, then click **Login**.
+2. Acquisition loads whatever it already has cached, then fetches your stash tab
+   list and downloads the checked tabs and characters.
+3. Use the search form at the top of the window to filter items. Each search
+   lives in its own tab; click **+** to open another.
+4. Select an item or a tab and set a price with the buyout controls under the
+   item list.
+5. To advertise those prices, set a forum shop thread and a POESESSID under the
+   **Shop** menu, then choose **Update forum shop(s)**.
+
+## Getting help
+
+- Issues: <https://github.com/gerwaric/acquisition/issues>
+- Discord: `gerwaric`
+
+## A note on this guide
+
+Acquisition is mature software that is being replaced by a from-scratch rewrite,
+so this guide is intentionally short and written from the source code rather than
+from screenshots. Menu and dialog names are quoted exactly as they appear in the
+application. If something here disagrees with the program, the program wins —
+please open an issue so the page can be corrected.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -22,8 +22,8 @@ Acquisition is neither affiliated with nor endorsed by Grinding Gear Games.
 
 1. Launch Acquisition and click **Authenticate**. A browser window opens for the
    Path of Exile OAuth grant. Pick a realm and league, then click **Login**.
-2. Acquisition loads whatever it already has cached, then fetches your stash tab
-   list and downloads the checked tabs and characters.
+2. Acquisition loads whatever it already has cached, then upon your request,
+   fetches your stash tab list and downloads the checked tabs and characters.
 3. Use the search form at the top of the window to filter items. Each search
    lives in its own tab; click **+** to open another.
 4. Select an item or a tab and set a price with the buyout controls under the
@@ -38,8 +38,6 @@ Acquisition is neither affiliated with nor endorsed by Grinding Gear Games.
 
 ## A note on this guide
 
-Acquisition is mature software that is being replaced by a from-scratch rewrite,
-so this guide is intentionally short and written from the source code rather than
-from screenshots. Menu and dialog names are quoted exactly as they appear in the
+Menu and dialog names are quoted exactly as they appear in the
 application. If something here disagrees with the program, the program wins —
 please open an issue so the page can be corrected.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -38,6 +38,9 @@ Acquisition is neither affiliated with nor endorsed by Grinding Gear Games.
 
 ## A note on this guide
 
+This guide first shipped with Acquisition 0.18.5 and is new; earlier versions
+had no user documentation, so expect gaps.
+
 Menu and dialog names are quoted exactly as they appear in the
 application. If something here disagrees with the program, the program wins —
 please open an issue so the page can be corrected.

--- a/docs/user/currency.md
+++ b/docs/user/currency.md
@@ -1,0 +1,27 @@
+# Currency
+
+Every refresh counts the currency items in your stashes and characters.
+
+## Currency overview
+
+**Currency → List currency...** opens a table with one row per currency type
+(the twenty types listed in [Pricing](pricing.md#currencies)) and the columns:
+
+- **Name** and **Count**
+- **Amount a chaos Orb can buy** / **Value in Chaos Orb**
+- **Amount an Exalted Orb can buy** / **Value in Exalted Orb**
+
+The *Amount … can buy* fields are ratios you enter yourself (for example, how
+many Alteration Orbs one Chaos buys); Acquisition does not fetch market rates.
+Totals at the bottom show **Total Chaos Orbs**, **Total Exalted Orbs**, and
+**Total Scrolls of Wisdom**. The **show chaos ratio** and **show exalt ratio**
+check boxes hide or reveal the ratio columns and are remembered between runs.
+
+The dialog stays open and updates as refreshes complete.
+
+## Export
+
+**Currency → Export to CSV...** writes a history file (default name
+`acquisition_export_currency.csv` in your home directory) with a `Date` column,
+a `Total value` column, and one column per currency type. Each row is a snapshot
+taken at a refresh, so the file can be charted to see your wealth over time.

--- a/docs/user/forum-shop.md
+++ b/docs/user/forum-shop.md
@@ -1,0 +1,39 @@
+# Forum shop
+
+The official trade site indexes the *Trading* forums, so a forum thread that
+lists your priced items makes them searchable there — including items in
+remove-only tabs and character inventories, which the site does not index from
+your stash directly. Acquisition writes and updates those threads for you.
+
+## One-time setup
+
+1. Create one or more threads in the appropriate Trading forum on
+   pathofexile.com. Note the number in each thread's URL.
+2. **Shop → Forum shop thread…** — enter the thread number. Enter several,
+   separated by commas, if you have more items than fit in one post; Acquisition
+   spreads the items across them in order. The menu item shows the configured
+   numbers, e.g. *Forum shop thread... [1234567]*.
+3. **Shop → Update shop POESESSID** — paste your `POESESSID` cookie from
+   pathofexile.com. OAuth cannot edit forum posts, so this cookie is required.
+   The same dialog is under **Settings → POESESSID**. If the site rejects the
+   cookie, Acquisition warns you and stops updating until you enter a new one.
+
+## Publishing
+
+- **Shop → Update forum shop(s)** rewrites every configured thread with the
+  current buyouts. Each item is wrapped in a `[spoiler]` with its price prefix,
+  and the whole list is placed where `[items]` appears in the template.
+- **Shop → Automatically update shop** (checkable) republishes after every
+  refresh, but only if something changed since the last post.
+- **Shop → Copy shop data to clipboard** gives you the generated forum markup
+  without posting, for pasting by hand.
+
+Items priced *[Ignore]* are omitted; *No price* items appear without a tag.
+Which tag each buyout type produces is listed in [Pricing](pricing.md).
+
+## The template
+
+**Shop → Edit Shop Template** opens the text that becomes the thread body. The
+default is simply `[items]`. Anything else you type — a greeting, contact
+details, rules — is kept, and `[items]` is replaced with the generated list.
+The template is applied to every thread.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -1,0 +1,77 @@
+# Getting started
+
+## Installing
+
+Download a package for Windows, macOS, or Linux from the
+[releases page](https://github.com/gerwaric/acquisition/releases). On Windows the
+installer also offers the Microsoft Visual C++ runtime; accept it unless you know
+you already have a current one. To build from source, see [BUILD.md](../../BUILD.md).
+
+## Logging in
+
+The login window has an **OAuth** tab with an **Authenticate** button.
+
+1. Click **Authenticate**. Your web browser opens the Path of Exile OAuth page.
+   Approve the request. The button changes to *Re-authenticate (as someone else)*
+   and the label shows *You are authenticated as "<account>"*.
+2. Choose a **Realm** (PC, Xbox, or PlayStation) and a **League**. The league
+   list is fetched live, so an error here usually means the Path of Exile API is
+   unreachable.
+3. Click **Login**. The button is disabled until you are authenticated and a
+   league is selected.
+
+Acquisition keeps the OAuth token, so on later launches you only need to click
+**Login**. The token is refreshed at startup; if the refresh fails you will see
+*The OAuth token needs to be refreshed* or *The OAuth token is not valid* — click
+**Authenticate** again.
+
+OAuth covers reading your stashes and characters. Posting to forum shop threads
+still needs a POESESSID cookie; see [Forum shop](forum-shop.md).
+
+### Advanced options
+
+**Show Advanced Options** reveals:
+
+| Option | Effect |
+|---|---|
+| Remember me | Keep the account and league for the next launch |
+| Report crashes | Send crash reports to the developer via Sentry |
+| Use system proxy | Route network traffic through the operating system's proxy settings |
+| Logging Level | Same as the **Settings → Logging** menu in the main window |
+| Theme | Dark, Light, or Default (the platform theme) |
+| Profile Folder | Shows the data directory in use (see below) |
+
+## What happens after login
+
+The main window title reads `Acquisition [version] - <League> League [<account>]`.
+
+Acquisition first loads any items it cached from a previous session, so a large
+account is searchable within seconds of logging in. It then fetches the stash
+tab list from the API. Tabs and characters that are **checked** in the item list
+are downloaded next; unchecked ones are skipped. See
+[Settings and troubleshooting](settings-and-troubleshooting.md#refreshing-items)
+for the refresh modes and [Searching](searching.md) for the layout of the window.
+
+## Where your data lives
+
+Everything Acquisition writes goes into one data directory:
+
+| Platform | Default |
+|---|---|
+| Windows | `%localappdata%\acquisition` |
+| macOS | `~/Library/Application Support/acquisition` |
+| Linux | `~/.local/share/acquisition` |
+
+Inside it you will find `settings.ini`, `log.txt`, a `data/` folder with one
+SQLite database per account (`userstore-<account>.db`) plus the legacy
+per-league databases, and a `cache/` folder for item images.
+
+Use `--data-dir <path>` to run with a different directory, for example to keep
+two accounts apart or to try a beta without touching your real data:
+
+```
+acquisition --data-dir /path/to/other/dir
+```
+
+The other command-line option is `--log-level <level>`; see
+[Settings and troubleshooting](settings-and-troubleshooting.md#logging).

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -4,8 +4,8 @@
 
 Download a package for Windows, macOS, or Linux from the
 [releases page](https://github.com/gerwaric/acquisition/releases). On Windows the
-installer also offers the Microsoft Visual C++ runtime; accept it unless you know
-you already have a current one. To build from source, see [BUILD.md](../../BUILD.md).
+installer will update the Microsoft Visual C++ runtime and may need a reboot. To
+build from source, see [BUILD.md](../../BUILD.md).
 
 ## Logging in
 
@@ -16,7 +16,7 @@ The login window has an **OAuth** tab with an **Authenticate** button.
    and the label shows *You are authenticated as "<account>"*.
 2. Choose a **Realm** (PC, Xbox, or PlayStation) and a **League**. The league
    list is fetched live, so an error here usually means the Path of Exile API is
-   unreachable.
+   unreachable. You can manually edit this field to specify a **Private League**.
 3. Click **Login**. The button is disabled until you are authenticated and a
    league is selected.
 
@@ -35,7 +35,7 @@ still needs a POESESSID cookie; see [Forum shop](forum-shop.md).
 | Option | Effect |
 |---|---|
 | Remember me | Keep the account and league for the next launch |
-| Report crashes | Send crash reports to the developer via Sentry |
+| Report crashes | Send crash reports to the developer via [Sentry](https://sentry.io) |
 | Use system proxy | Route network traffic through the operating system's proxy settings |
 | Logging Level | Same as the **Settings → Logging** menu in the main window |
 | Theme | Dark, Light, or Default (the platform theme) |
@@ -46,9 +46,9 @@ still needs a POESESSID cookie; see [Forum shop](forum-shop.md).
 The main window title reads `Acquisition [version] - <League> League [<account>]`.
 
 Acquisition first loads any items it cached from a previous session, so a large
-account is searchable within seconds of logging in. It then fetches the stash
-tab list from the API. Tabs and characters that are **checked** in the item list
-are downloaded next; unchecked ones are skipped. See
+account is searchable within seconds of logging in. Then you can use it to fetch
+the stash tab list from the API. You can refresh **all tabs**, **checked tabs**,
+or **selected tabs** using the right click context menu and/or menubar. See
 [Settings and troubleshooting](settings-and-troubleshooting.md#refreshing-items)
 for the refresh modes and [Searching](searching.md) for the layout of the window.
 

--- a/docs/user/mods-and-pseudomods.md
+++ b/docs/user/mods-and-pseudomods.md
@@ -1,0 +1,75 @@
+# Mods and pseudomods
+
+## The Mods filter
+
+The **Mods** section of the search form holds any number of rows. Each row is a
+searchable drop-down of modifier names plus optional **min** and **max** boxes.
+Click **Add mod** for another row and **X** to remove one. An item matches only
+if it has *every* listed mod, with each value inside its range.
+
+The drop-down filters as you type: every space-separated word you enter must
+appear somewhere in the mod name, case-insensitively, in any order. Typing
+`total fire` shows `+#% total to Fire Resistance`; typing `socketed minion`
+shows `+# total to Level of Socketed Minion Gems`.
+
+Mod names use `#` as the placeholder for the number, exactly as the trade site
+does. Implicit, explicit, crafted, enchant, fractured, and other affix lines are
+all included; a mod that appears more than once on an item (for example the same
+line as implicit and explicit) is summed into a single value.
+
+## Pseudomods
+
+Pseudomods are synthetic modifiers whose value is the **sum of several real
+mods** on the item. They appear in the same drop-down as ordinary mods and are
+always named `… total …`. They exist so you can search for "at least 100 total
+elemental resistance" without enumerating every combination of single, dual, and
+all-resistance lines. The list mirrors the one poe.trade used.
+
+Both implicit and explicit lines feed into the sum. A pseudomod is only present
+on an item that has at least one of its contributing mods.
+
+### Resistances
+
+| Pseudomod | Sums |
+|---|---|
+| `+#% total to Fire Resistance` | Fire; Fire and Cold; Fire and Lightning; Fire and Chaos; all Elemental |
+| `+#% total to Cold Resistance` | Cold; Fire and Cold; Cold and Lightning; Cold and Chaos; all Elemental |
+| `+#% total to Lightning Resistance` | Lightning; Fire and Lightning; Cold and Lightning; Lightning and Chaos; all Elemental |
+| `+#% total to Chaos Resistance` | Chaos; Fire and Chaos; Cold and Chaos; Lightning and Chaos |
+| `+#% total Elemental Resistance` | Fire + Cold + Lightning totals (all-Elemental counts three times) |
+| `+#% total Resistance` | Elemental total + Chaos total |
+
+### Attributes
+
+| Pseudomod | Sums |
+|---|---|
+| `+# total to Strength` | Strength; Strength and Dexterity; Strength and Intelligence; all Attributes |
+| `+# total to Dexterity` | Dexterity; Strength and Dexterity; Dexterity and Intelligence; all Attributes |
+| `+# total to Intelligence` | Intelligence; Strength and Intelligence; Dexterity and Intelligence; all Attributes |
+
+### Speed, damage, and crit
+
+| Pseudomod | Sums |
+|---|---|
+| `+#% total Attack Speed` | `#% increased Attack Speed` |
+| `+#% total Cast Speed` | `#% increased Cast Speed` |
+| `+#% total increased Physical Damage` | `#% increased Physical Damage`; `#% increased Global Physical Damage` |
+| `+#% total Critical Strike Chance for Spells` | `#% increased Spell Critical Strike Chance`; `#% increased Global Critical Strike Chance` |
+
+### Socketed gem levels
+
+`+# total to Level of Socketed … Gems` exists for **Gems** (the generic line
+alone), Elemental, Fire, Cold, Lightning, Chaos, Spell, Projectile, Bow, Melee,
+Minion, Strength, Dexterity, Intelligence, Aura, Movement, Curse, Vaal, Support,
+Skill, Warcry, and Golem. Each sums its own specific line with the generic
+`+# to Level of Socketed Gems`; Fire, Cold, and Lightning also include
+`+# to Level of Socketed Elemental Gems`.
+
+For example, on an item with `+1 to Level of Socketed Gems` and `+2 to Level of
+Socketed Fire Gems`, `+# total to Level of Socketed Fire Gems` is 3.
+
+### Where the list lives
+
+The authoritative list is `src/pseudomods.cpp` in the source tree. If you want
+another pseudomod, that file is the only place to add it — the drop-down and the
+per-item sums are both generated from it.

--- a/docs/user/mods-and-pseudomods.md
+++ b/docs/user/mods-and-pseudomods.md
@@ -13,9 +13,12 @@ appear somewhere in the mod name, case-insensitively, in any order. Typing
 shows `+# total to Level of Socketed Minion Gems`.
 
 Mod names use `#` as the placeholder for the number, exactly as the trade site
-does. Implicit, explicit, crafted, enchant, fractured, and other affix lines are
-all included; a mod that appears more than once on an item (for example the same
-line as implicit and explicit) is summed into a single value.
+does. Unlike the trade site, Acquisition does **not** separate implicit,
+explicit, crafted, enchant, or fractured lines: they all go into one table
+keyed by mod name, so a single row matches the line wherever it appears on the
+item. If the same line occurs twice on one item (for example as both an implicit
+and an explicit), only one value is kept for that name; use the
+`… total …` pseudomods below when you need lines added together.
 
 ## Pseudomods
 

--- a/docs/user/pricing.md
+++ b/docs/user/pricing.md
@@ -1,0 +1,66 @@
+# Pricing
+
+Acquisition calls a price a **buyout**. Buyouts are stored in your data directory,
+never in the game, and are what the [forum shop](forum-shop.md) publishes.
+
+## Setting a price
+
+Select an item, or a whole stash tab or character, in the item list. The three
+controls under the list are:
+
+1. **Buyout type**
+2. **Currency**
+3. **Value**
+
+Changes apply immediately to the selection. The *Price* and *Last Update* columns
+in the item table show the result.
+
+### Buyout types
+
+| Type | Forum tag | Meaning |
+|---|---|---|
+| Buyout | `~b/o` | Asking price; buyers may still offer less |
+| Fixed price | `~price` | Non-negotiable price |
+| Current Offer | `~c/o` | The best offer received so far |
+| No price | — | Listed in the shop with no price |
+| [Ignore] | — | Excluded from the shop entirely |
+| [Inherit] | — | Use the tab's buyout (the default for items) |
+
+### Tab prices and inheritance
+
+Pricing a stash tab or character prices every item in it that is still on
+*[Inherit]*. Setting an item's own buyout overrides the tab's for that item;
+setting it back to *[Inherit]* restores the tab price. *Current Offer* is not
+meaningful for a tab and is logged as obsolete if it is found on one.
+
+### Currencies
+
+Alteration, Fusing, Alchemy, Chaos, Gemcutter's Prism, Exalted, Chromatic,
+Jeweller's, Chance, Cartographer's Chisel, Scouring, Blessed, Regret, Regal,
+Divine, Vaal, Perandus Coin, Mirror of Kalandra, Silver Coin. The forum tags are
+the usual short forms (`chaos`, `exa`, `divine`, `fuse`, …).
+
+## Prices set in the game
+
+If a stash tab's name, or an item's note, contains a trade-site price string such
+as `~b/o 5 chaos` or `~price 1 divine`, Acquisition imports it as a buyout with
+source *game*. Game-sourced prices are **locked**: you cannot change them in
+Acquisition, because the next refresh would overwrite the change. Edit the tab
+name or item note in the game instead. Tabs priced in the game are always
+refreshed regardless of their check box, so their prices stay current.
+
+## Recovering prices from old versions
+
+Before version 0.16, Acquisition stored buyouts in a different database. Two
+items under the **Buyouts** menu bring them forward:
+
+- **Recover legacy buyouts…** — choose a pre-0.16 data file. Acquisition matches
+  the old buyouts against the current stashes and characters and shows how many
+  it matched, how many are ambiguous, and how many are orphaned. You can
+  **Import now**, or **Save plan for review…** to get an editable `.xlsx`
+  workbook.
+- **Import buyout plan…** — apply a saved (and optionally edited) plan. Each row
+  has an *action* of `import` or `skip`.
+
+Run a full refresh of stashes and characters first so the matcher has current
+data. Existing manual buyouts are never overwritten by the importer.

--- a/docs/user/searching.md
+++ b/docs/user/searching.md
@@ -1,0 +1,68 @@
+# Searching
+
+## The main window
+
+From top to bottom:
+
+- **Search tabs.** Each tab is an independent search with its own filters. The
+  trailing **+** tab creates a new one. Tab captions show the search name and the
+  number of matching items, e.g. `Rings [42]`. Right-click a tab for
+  **Rename Tab** and **Delete Tab**; middle-click closes a tab.
+- **Search form.** Text fields, drop-downs, min/max ranges, and check boxes,
+  grouped under *Offense*, *Defense*, *Sockets*, *Requirements*, *Misc*, and
+  *Mods*. Searches update as you type.
+- **View selector.** *By Tab* groups items under the stash tab or character they
+  came from; *By Item* is a flat list.
+- **Item list.** A tree of tabs/characters and their items. The check box on a
+  tab or character controls whether it is included in **Refresh checked tabs**.
+  Right-click for **Refresh Selected**, **Check Selected**, **Uncheck Selected**,
+  **Check All**, **Uncheck All**, **Expand All**, and **Collapse All**.
+- **Buyout controls** under the list — see [Pricing](pricing.md).
+- **Item panel** on the right: the item's name, an in-game-style **Tooltip** tab,
+  a plain **Text** tab, and **Hide**. **Upload to imgur** uploads the rendered
+  tooltip and copies the URL to the clipboard; **Copy for Path of Building**
+  copies the item in Path of Building's *Create custom* format.
+- **Status bar** with the current activity, a **Rate Limit Status** button, and
+  an **Update available** button when a newer release exists.
+- **Event Log** at the bottom. Collapsed by default; its button changes to
+  *N error(s)* or *N warning(s)* when something needs attention.
+
+## Filters
+
+All filters are ANDed together. Min/max fields are inclusive and either side may
+be left blank. Check boxes match only when checked.
+
+| Group | Filter | Matches |
+|---|---|---|
+| Top row | Tab | Substring of the stash tab or character name |
+| | Name | Substring of the item name |
+| | Type | Item category (from the game's item classes); `<any>` disables it |
+| | Rarity | `<any>`, Normal, Magic, Rare, Unique, Unique (Foil), Any Non-Unique |
+| Offense | Crit. | Critical Strike Chance |
+| | DPS, pDPS, eDPS, cDPS | Total, physical, elemental, and chaos DPS |
+| | APS | Attacks per Second |
+| Defense | Armour, Evasion, Shield, Block | Armour, Evasion Rating, Energy Shield, Chance to Block |
+| Sockets | Sockets | Number of sockets |
+| | Links | Size of the largest linked group |
+| | Colors R/G/B | At least this many sockets of each colour |
+| | Linked R/G/B | At least this many of each colour in one linked group |
+| Requirements | R. Level, R. Str, R. Dex, R. Int | Requirement values |
+| Misc | Quality | Quality (unlisted quality counts as 0) |
+| | Level | Gem level, or the *Level* property on other items |
+| | Map Tier | Map tier |
+| | ilvl | Item level |
+| Flags | Alt. art | Alternate-art items |
+| | Priced | Items with an active buyout |
+| | Unidentified, Influenced, Crafted, Enchanted, Corrupted, Fractured, Split, Synthesized, Mutated | The corresponding item flag |
+| Mods | Mods | Modifier rows; see [Mods and pseudomods](mods-and-pseudomods.md) |
+
+*Influenced* means Shaper, Elder, Crusader, Redeemer, Hunter, or Warlord only;
+fractured, synthesised, and eldritch items have their own filters.
+
+## Item table columns
+
+Name · Price · Last Update · Q (quality) · Stack · Corr · Mast (crafted) · Ench ·
+Inf (S/E/H/W/C/R for the six influences) · PD · ED (three elemental columns) ·
+CD · APS · DPS · pDPS · eDPS · cDPS · Crit · Ar · Ev · ES · B · Lvl · ilvl.
+
+Click a column header to sort. *Last Update* is when the price was last changed.

--- a/docs/user/settings-and-troubleshooting.md
+++ b/docs/user/settings-and-troubleshooting.md
@@ -74,3 +74,7 @@ options from the login window and the menus.
 | *POESESSID has not been set* / rejected | Enter a fresh cookie under **Shop → Update shop POESESSID** |
 | Cannot change a price | The price comes from the game (tab name or item note); change it there |
 | Windows: crash at startup in `MSVCP140.dll` | Install the Visual C++ runtime the installer offers |
+
+## Getting help
+
+The best place to look or ask is [GitHub Issues](https://github.com/gerwaric/acquisition/issues).

--- a/docs/user/settings-and-troubleshooting.md
+++ b/docs/user/settings-and-troubleshooting.md
@@ -73,7 +73,7 @@ options from the login window and the menus.
 | *No forum threads have been set* | Set a thread under **Shop → Forum shop thread…** |
 | *POESESSID has not been set* / rejected | Enter a fresh cookie under **Shop → Update shop POESESSID** |
 | Cannot change a price | The price comes from the game (tab name or item note); change it there |
-| Windows: crash at startup in `MSVCP140.dll` | Install the Visual C++ runtime the installer offers |
+| Windows: crash at startup in `MSVCP140.dll` | An outdated Visual C++ runtime; re-run the installer (it updates the runtime) and reboot if asked |
 
 ## Getting help
 

--- a/docs/user/settings-and-troubleshooting.md
+++ b/docs/user/settings-and-troubleshooting.md
@@ -1,0 +1,76 @@
+# Settings and troubleshooting
+
+## Refreshing items
+
+The **Tabs** menu:
+
+| Item | What it does |
+|---|---|
+| Fetch tabs list | Downloads the list of stash tabs and characters only, without their contents |
+| Refresh checked tabs | Downloads the tabs and characters whose check box in the item list is ticked |
+| Refresh all tabs | Downloads everything |
+| Auto refresh checked tabs | Checkable; repeats *Refresh checked tabs* on a timer |
+| Auto refresh interval... | Sets that timer in minutes |
+| Get map stashes / Get unique stashes | Checkable; also download the sub-tabs of Map and Unique stash tabs |
+
+Right-click one or more tabs in the item list and choose **Refresh Selected** to
+update just those. Tabs whose price is set in the game are always refreshed.
+
+Items already on disk are shown immediately at startup; the refresh replaces
+them tab by tab as downloads finish.
+
+## Rate limiting
+
+The Path of Exile API limits how fast Acquisition may fetch. Acquisition reads the
+limits the API sends back and paces itself, so a large account simply takes a
+while. The status bar button reads **Rate Limit Status** normally, or
+*Rate limited for N seconds* while waiting. Clicking it opens the
+**Rate Limit Status Window**, which lists each policy and rule with its current
+hits, limit, period, and timeout. Nothing here needs configuring; it exists so
+you can see why a refresh is paused.
+
+## Settings menu
+
+- **Theme** — Dark, Light, or Default. Applied immediately.
+- **Logging** — OFF, FATAL, ERROR, WARN, INFO, DEBUG, or TRACE. The default is
+  INFO.
+- **POESESSID** — Show or edit the session cookie used for forum posting.
+
+## Logging
+
+Log output goes to the **Event Log** panel at the bottom of the window and to
+`log.txt` in the data directory. When reporting a problem, set the level to
+DEBUG, reproduce it, and attach `log.txt`. You can also start with
+`acquisition --log-level DEBUG`.
+
+## Updates
+
+Acquisition checks the GitHub releases at startup. When a newer version exists,
+an **Update available** button appears in the status bar; clicking it opens the
+download page. Pre-releases are offered separately from stable releases, and a
+version you dismiss is not offered again.
+
+## Crash reports
+
+With **Report crashes** enabled on the login window, native crashes are sent to
+the developer through Sentry. Reports contain a stack trace and the Acquisition
+version; they do not include your item data.
+
+## Files and where to find them
+
+See [Getting started](getting-started.md#where-your-data-lives) for the data
+directory. Deleting `data/` forces a full re-download and loses your buyouts;
+deleting `cache/` only loses cached item images; `settings.ini` holds the
+options from the login window and the menus.
+
+## Common problems
+
+| Symptom | Likely cause |
+|---|---|
+| *Error requesting leagues* on the login window | The API is unreachable; check your connection or proxy |
+| Login button stays disabled | You have not authenticated, or no league is selected |
+| Refresh seems stuck | Open the Rate Limit Status Window; the API is probably throttling |
+| *No forum threads have been set* | Set a thread under **Shop → Forum shop thread…** |
+| *POESESSID has not been set* / rejected | Enter a fresh cookie under **Shop → Update shop POESESSID** |
+| Cannot change a price | The price comes from the game (tab name or item note); change it there |
+| Windows: crash at startup in `MSVCP140.dll` | Install the Visual C++ runtime the installer offers |

--- a/src/ratelimit/ratelimitdialog.h
+++ b/src/ratelimit/ratelimitdialog.h
@@ -15,6 +15,10 @@ class QString;
 
 class RateLimiter;
 class RateLimitPolicy;
+// The generated moc file registers signals/slots that take a RateLimitPolicy,
+// so it needs the full type, not the forward declaration (GCC 16
+// -Wsfinae-incomplete, issue #217).
+Q_MOC_INCLUDE("ratelimit/ratelimitpolicy.h")
 
 class RateLimitDialog : public QDialog
 {

--- a/src/ratelimit/ratelimiter.h
+++ b/src/ratelimit/ratelimiter.h
@@ -30,6 +30,10 @@ class NetworkCapture;
 class NetworkManager;
 class RateLimitManager;
 class RateLimitPolicy;
+// The generated moc file registers signals/slots that take a RateLimitPolicy,
+// so it needs the full type, not the forward declaration (GCC 16
+// -Wsfinae-incomplete, issue #217).
+Q_MOC_INCLUDE("ratelimit/ratelimitpolicy.h")
 
 // The hub (network-redesign spec, D4/D5): endpoint-to-policy topology, HEAD
 // setup, the gate, and capture. Every endpoint the hub knows is in exactly

--- a/src/ratelimit/ratelimitmanager.h
+++ b/src/ratelimit/ratelimitmanager.h
@@ -25,6 +25,10 @@ class QNetworkReply;
 
 class NetworkCapture;
 class RateLimitPolicy;
+// The generated moc file registers signals/slots that take a RateLimitPolicy,
+// so it needs the full type, not the forward declaration (GCC 16
+// -Wsfinae-incomplete, issue #217).
+Q_MOC_INCLUDE("ratelimit/ratelimitpolicy.h")
 
 namespace RateLimit {
     class Gate;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -7,6 +7,7 @@
 #include <QApplication>
 #include <QBuffer>
 #include <QClipboard>
+#include <QDesktopServices>
 #include <QDir>
 #include <QEvent>
 #include <QFile>
@@ -512,6 +513,15 @@ void MainWindow::InitializeUi()
 
     // Connect the POESESSID submenu.
     connect(ui->actionShowPOESESSID, &QAction::triggered, this, &MainWindow::OnShowPOESESSID);
+
+    // Help menu
+    connect(ui->actionOpenUserGuide, &QAction::triggered, this, [] {
+        QDesktopServices::openUrl(
+            QUrl("https://github.com/gerwaric/acquisition/blob/master/docs/user/README.md"));
+    });
+    connect(ui->actionReportIssue, &QAction::triggered, this, [] {
+        QDesktopServices::openUrl(QUrl("https://github.com/gerwaric/acquisition/issues"));
+    });
 
     // Connect the Tooltip tab buttons
     connect(ui->uploadTooltipButton, &QPushButton::clicked, this, &MainWindow::OnUploadToImgur);

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -441,13 +441,6 @@
      <addaction name="actionLoggingDEBUG"/>
      <addaction name="actionLoggingTRACE"/>
     </widget>
-    <widget class="QMenu" name="menuOAuth">
-     <property name="title">
-      <string>OAuth</string>
-     </property>
-     <addaction name="actionShowOAuthToken"/>
-     <addaction name="actionRefreshOAuthToken"/>
-    </widget>
     <widget class="QMenu" name="menuSessionID">
      <property name="title">
       <string>POESESSID</string>
@@ -456,7 +449,6 @@
     </widget>
     <addaction name="menuTheme"/>
     <addaction name="menuLogging"/>
-    <addaction name="menuOAuth"/>
     <addaction name="menuSessionID"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
@@ -649,16 +641,6 @@
    </property>
    <property name="text">
     <string>TRACE</string>
-   </property>
-  </action>
-  <action name="actionShowOAuthToken">
-   <property name="text">
-    <string>Show Token</string>
-   </property>
-  </action>
-  <action name="actionRefreshOAuthToken">
-   <property name="text">
-    <string>Refresh Token</string>
    </property>
   </action>
   <action name="actionOpenUserGuide">

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -574,11 +574,6 @@
     <string>Light</string>
    </property>
   </action>
-  <action name="actionRefresh_Mod_List">
-   <property name="text">
-    <string>Refresh Mod List</string>
-   </property>
-  </action>
   <action name="actionSetDefaultTheme">
    <property name="checkable">
     <bool>true</bool>

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -459,11 +459,19 @@
     <addaction name="menuOAuth"/>
     <addaction name="menuSessionID"/>
    </widget>
+   <widget class="QMenu" name="menuHelp">
+    <property name="title">
+     <string>Help</string>
+    </property>
+    <addaction name="actionOpenUserGuide"/>
+    <addaction name="actionReportIssue"/>
+   </widget>
    <addaction name="menuTabs"/>
    <addaction name="menuShop"/>
    <addaction name="menuBuyouts"/>
    <addaction name="menuCurrency"/>
    <addaction name="menuSettings"/>
+   <addaction name="menuHelp"/>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionSetShopThreads">
@@ -651,6 +659,16 @@
   <action name="actionRefreshOAuthToken">
    <property name="text">
     <string>Refresh Token</string>
+   </property>
+  </action>
+  <action name="actionOpenUserGuide">
+   <property name="text">
+    <string>User guide (online)</string>
+   </property>
+  </action>
+  <action name="actionReportIssue">
+   <property name="text">
+    <string>Report an issue (online)</string>
    </property>
   </action>
   <action name="actionShowPOESESSID">


### PR DESCRIPTION
## Summary

- **User guide** — new `docs/user/` (8 pages: getting started, searching and filters, mods and the 35 \"total\" pseudomods, pricing, forum shop, currency, settings/troubleshooting), written from the source. Linked from the top-level README and `docs/README.md`. This is the first release with user documentation.
- **Help menu** — new *Help → User guide (online)* and *Report an issue (online)* in the main window.
- **Dead menu items removed** — the unconnected *Settings → OAuth* submenu (Show/Refresh Token) and the orphaned *Refresh Mod List* action.
- **GCC 16 `-Wsfinae-incomplete`** — `Q_MOC_INCLUDE` for `RateLimitPolicy` in the three headers whose moc output takes it by reference. Fixes #217.
- Version bumped to 0.18.5.

## Test plan

- [x] Release build on Linux/GCC 16.2.1 is warning-free
- [x] `ctest`: 39/39 pass
- [x] Check the Help menu links open in a browser on Windows/macOS packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sPEJHgzgGdYjtd8RmZYBK