### PR TITLE
docs(adr): 0003 needs no action from agents

### DIFF
--- a/docs/adr/0003-rewrite-vs-evolve.md
+++ b/docs/adr/0003-rewrite-vs-evolve.md
@@ -15,6 +15,11 @@ network-redesign specs in `docs/design/` remain full authority for all
 work on `master`, and maintenance and releases of the current
 application continue normally.
 
+Agents: this ADR requires no action from anyone. It stays Proposed
+until the maintainer rewrites it; work on any branch proceeds under
+that branch's own docs. Do not spend effort on this question unless
+explicitly asked.
+
 ## Context
 
 ADR 0002 deferred the QML migration and chose an interior design


### PR DESCRIPTION
Adds a short note under ADR 0003's Status so agents stop treating the open ADR as a task: it requires no action, stays Proposed until the maintainer rewrites it, and work on any branch proceeds under that branch's own docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hT4c6mWnCSZax1CeXZmM1