### PR TITLE
Release 0.18.6: PoE2 0.5.5 and PoE1 3.29.3b API object changes

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -151,6 +151,49 @@ sudo apt-get install -y \
 Other distributions may need equivalent packages. If Qt cannot find OpenSSL, set
 `OPENSSL_ROOT_DIR` or adjust your library path for your local installation.
 
+### Desktop Integration and LD_LIBRARY_PATH
+
+When Acquisition is run with `LD_LIBRARY_PATH` pointing at an official Qt
+installation, anything that opens an external URL or file can fail silently.
+This affects OAuth login, the Help menu links, the update download, and the
+crash-report links. The window appears and the rest of the application works,
+so the only sign is a message on stderr such as:
+
+```
+version `Qt_6.11_PRIVATE_API' not found (required by /lib64/libKF6WindowSystem.so.6)
+```
+
+Those paths depend on the distribution and desktop environment; the shape of
+the message is the part that matters.
+
+The cause is environment inheritance, not a bug in the application.
+`QDesktopServices::openUrl` hands the URL to `xdg-open`, which delegates to a
+desktop-specific helper, and that helper is a distribution binary linked
+against the distribution's Qt. The helper inherits `LD_LIBRARY_PATH` from
+Acquisition, so it loads the official kit's Qt libraries instead of the system
+ones. Distributions and the official Qt installers do not always tag private
+symbols the same way, so the helper's own dependencies then fail to resolve.
+Most helpers still exit successfully after this failure, which is why the
+application reports nothing and the browser simply never opens.
+
+Do not export `LD_LIBRARY_PATH` when running a local build. The binary's
+`RUNPATH` already points at the Qt kit, and the Qt libraries locate each other
+through `$ORIGIN`, so the application resolves its dependencies without it.
+Confirm this for a given build before changing anything else; the following
+should print nothing:
+
+```sh
+env -u LD_LIBRARY_PATH ldd ./build/acquisition | grep "not found"
+```
+
+In Qt Creator, both sources of the variable are in Projects -> Run:
+
+- Clear any `LD_LIBRARY_PATH` entry under Environment.
+- Uncheck "Add build library search path to LD_LIBRARY_PATH".
+
+Qt Creator rewrites `CMakeLists.txt.user` when it exits, so edit that file only
+while Qt Creator is closed, or make the change through the user interface.
+
 ## Release Packaging
 
 Release artifacts are built by GitHub Actions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.24)
 # tags on github are prefixed with a 'v'.
 
 project(acquisition
-    VERSION 0.18.5
+    VERSION 0.18.6
     DESCRIPTION "Stash and forum shop management for Path of Exile (TM)"
     HOMEPAGE_URL "https://github.com/gerwaric/acquisition"
     LANGUAGES CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,7 @@ set(ACQ_POE
     src/poe/types/league.h
     src/poe/types/leagueaccount.h
     src/poe/types/leaguerule.h
+    src/poe/types/mercenaryskill.h
     src/poe/types/passivegroup.h
     src/poe/types/passivenode.h
     src/poe/types/publicstashchange.h

--- a/src/poe/types/character.h
+++ b/src/poe/types/character.h
@@ -69,6 +69,7 @@ namespace poe {
         std::optional<std::vector<poe::Item>> rucksack;   // ?array of Item
         std::optional<std::vector<poe::Item>> jewels;     // ?array of Item
         std::optional<std::vector<poe::Item>> guardian;   // ?array of Item; PoE1 only
+        std::optional<int> active_mercenary_index;        // ?int; PoE1 only
         std::optional<poe::Character::Passives> passives; // ?object
         std::optional<poe::Character::Metadata> metadata; // ?object
 

--- a/src/poe/types/item.h
+++ b/src/poe/types/item.h
@@ -16,6 +16,7 @@
 #include "poe/types/itemmod.h"
 #include "poe/types/itemproperty.h"
 #include "poe/types/itemsocket.h"
+#include "poe/types/mercenaryskill.h"
 
 namespace poe {
 
@@ -59,22 +60,6 @@ namespace poe {
         {
             QString type;  // string text used to display ultimatum icons
             unsigned tier; // uint
-        };
-
-        struct MercenarySkills
-        {
-            struct Supports
-            {
-                unsigned hash; // uint
-                QString name;  // string
-                unsigned tier; // uint
-            };
-
-            unsigned hash; // uint
-            QString icon;  // string
-            QString name;  // string
-            std::optional<std::vector<poe::Item::MercenarySkills::Supports>>
-                supports; // ?array of object
         };
 
         struct IncubatingInfo
@@ -202,7 +187,7 @@ namespace poe {
         std::optional<std::vector<poe::Item::UltimatumMods>> ultimatumMods; // ? array of object
         std::optional<std::vector<poe::ItemMod>> explicitMods;              // ? array of ItemMod
         std::optional<std::vector<QString>> bondedMods;    // ? array of string; PoE2 only
-        std::optional<std::vector<poe::Item::MercenarySkills>> mercenarySkills; // ? array of object
+        std::optional<std::vector<poe::MercenarySkill>> mercenarySkills; // ? array of object
         std::optional<std::vector<QString>>
             crucibleMods; // ? array of string only allocated mods are included
         std::optional<std::vector<QString>> cosmeticMods; // ? array of string

--- a/src/poe/types/leagueaccount.h
+++ b/src/poe/types/leagueaccount.h
@@ -7,6 +7,9 @@
 
 #include <QString>
 
+#include "poe/types/item.h"
+#include "poe/types/mercenaryskill.h"
+
 namespace poe {
 
     // https://www.pathofexile.com/developer/docs/reference#type-LeagueAccount
@@ -19,7 +22,18 @@ namespace poe {
             std::vector<unsigned> hashes; // array of uint
         };
 
+        struct Mercenaries
+        {
+            QString name;
+            unsigned level;
+            QString build;
+            unsigned build_hash;
+            std::vector<poe::MercenarySkill> skills; // array of MercenarySkill
+            std::vector<poe::Item> items;            // array of Item
+        };
+
         std::vector<poe::LeagueAccount::AtlasPassiveTree> atlas_passive_trees; // array of object
+        std::vector<poe::LeagueAccount::Mercenaries> mercenaries;              // array of object
     };
 
 } // namespace poe

--- a/src/poe/types/mercenaryskill.h
+++ b/src/poe/types/mercenaryskill.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Tom Holz
+
+#pragma once
+
+#include <optional>
+
+#include <QString>
+
+namespace poe {
+
+    // https://www.pathofexile.com/developer/docs/reference#type-MercenarySkill
+
+    struct MercenarySkill
+    {
+        struct Support
+        {
+            unsigned hash;
+            QString name;
+            unsigned tier;
+        };
+
+        unsigned hash;
+        QString icon;
+        QString name;
+        std::optional<std::vector<poe::MercenarySkill::Support>> supports; // ?array of object
+    };
+
+} // namespace poe


### PR DESCRIPTION
Opens the 0.18.6 release branch for the API object changes that came with
PoE2 0.5.5 and PoE1 3.29.3b.

## Changes

**Version** — bumps the project version to 0.18.6. `CMakeLists.txt` is the only
version source; `installer.iss` and the workflows read it through
`version_defines.h`, so nothing else needed touching. `app_version_suffix` is
left empty (no pre-release).

**API objects**
- Adds `poe::MercenarySkill` in its own header, replacing the nested
  `Item::MercenarySkills` so `Item` and `LeagueAccount` share one definition.
- Adds `LeagueAccount::Mercenaries` and the `mercenaries` field. GGG does not
  mark the field optional and the league-account endpoint is PoE1 only, so it
  is a plain `std::vector`, matching `atlas_passive_trees`.
- Adds `Character::active_mercenary_index` (PoE1 only, optional).

**Build docs** — documents a Linux issue hit while testing this branch. Running
a local build with `LD_LIBRARY_PATH` pointing at an official Qt kit makes
`QDesktopServices::openUrl` fail silently: the desktop helper that `xdg-open`
delegates to inherits the variable and loads the kit's Qt instead of the
distribution's, so its own dependencies fail to resolve. Most helpers still
exit successfully, so nothing surfaces in the application and OAuth login
simply never opens a browser. The note is distro- and desktop-agnostic and
covers the fix in both places Qt Creator sets the variable.

## Testing

- A basic stash refresh passed against the updated types.
- The changed headers compile clean together (`g++ -std=c++23 -fsyntax-only`
  with the glaze and Qt include paths).
- No stale references to the removed `Item::MercenarySkills` remain in `src/`
  or `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UwPQ6tTu5CVd4rT6oRmHg